### PR TITLE
At least two lines in history to be considered as failed

### DIFF
--- a/extra/history_files/sequence_LST1_04183_oneline.history
+++ b/extra/history_files/sequence_LST1_04183_oneline.history
@@ -1,0 +1,1 @@
+02963 lstchain_data_create_drs4_pedestal_file v0.1.0 Thu Dec 09 15:46:06 UTC 2021 drs4_pedestal.Run02963.0000.fits onsite_camera_calibration_param.json 1

--- a/osa/tests/test_veto.py
+++ b/osa/tests/test_veto.py
@@ -3,11 +3,21 @@ from pathlib import Path
 
 def test_failed_history():
     from osa.veto import failed_history
-    good_history_file = Path('./extra/history_files/sequence_LST1_04183.history')
-    bad_history_file = Path('./extra/history_files/sequence_LST1_04183_failed.history')
+    good_history_file = Path(
+        './extra/history_files/sequence_LST1_04183.history'
+    )
+    bad_history_file = Path(
+        './extra/history_files/sequence_LST1_04183_failed.history'
+    )
+    one_line_history_file = Path(
+        './extra/history_files/sequence_LST1_04183_oneline.history'
+    )
+    one_line_history = failed_history(one_line_history_file)
     good_history_failed = failed_history(good_history_file)
     bad_history_failed = failed_history(bad_history_file)
+
     assert good_history_failed is False
+    assert one_line_history is False
     assert bad_history_failed is True
 
 

--- a/osa/veto.py
+++ b/osa/veto.py
@@ -54,18 +54,24 @@ def update_vetoes(sequence_list):
             log.debug(f"Created veto file {sequence.veto}")
 
 
-def failed_history(history_file) -> bool:
+def failed_history(history_file: Path) -> bool:
     """
     Check if a processing step has failed twice in a given history file.
 
     Return True if the last line of the history file contains a non-zero exit
-    status and is repeated by maximum trials times.
+    status and is repeated twice, meaning that a given step has failed twice.
     """
     history_lines = history_file.read_text().splitlines()
 
+    # Check if history file has at least two trials
+    if len(history_lines) < 2:
+        return False
+
+    # Check if the last line of the history file is repeated twice
+    # and the exit status is non-zero
     return (
         history_lines[-1] == history_lines[-2]
-        and history_lines[-1].split() != "0"
+        and history_lines[-1].split()[-1] != "0"
     )
 
 


### PR DESCRIPTION
Make sure that failed history function checks failed history files with more than two lines. Added test.