### PR TITLE
Exit sequencer when no runs are found

### DIFF
--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -1,6 +1,7 @@
 """Extract subrun, run, sequence list and build corresponding objects."""
 
 import logging
+import sys
 
 from astropy import units as u
 from astropy.time import Time
@@ -83,7 +84,8 @@ def extractsubruns(summary_table):
     log.debug("Subrun list extracted")
 
     if not subrun_list:
-        raise SystemExit("No runs found for this date. Nothing to do. Exiting.")
+        log.warning("No runs found for this date. Nothing to do. Exiting.")
+        sys.exit(0)
 
     return subrun_list
 
@@ -267,7 +269,8 @@ def extractsequences(run_list):
     log.debug("Sequence list extracted")
 
     if not store:
-        raise SystemExit("No data sequences found for this date. Nothing to do. Exiting.")
+        log.warning("No data sequences found for this date. Nothing to do. Exiting.")
+        sys.exit(0)
 
     return sequence_list
 

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -360,5 +360,5 @@ def test_no_runs_found():
         stdout=sp.PIPE,
         stderr=sp.PIPE
     )
-    assert output.returncode != 0
-    assert output.stderr.splitlines()[-1] == "No runs found for this date. Nothing to do. Exiting."
+    assert output.returncode == 0
+    assert "No runs found for this date. Nothing to do. Exiting." in output.stderr.splitlines()[-1]


### PR DESCRIPTION
Autocloser runs `sequencer -s` before closing. If no runs are found by sequencer when extracting the run sequences, a flag is set in the dl1 datacheck web. Therefore sequencer has to exit with exit code 0 if no runs are found.