### PR TITLE
DL2 to DL3 step implementation

### DIFF
--- a/cfg/sequencer.cfg
+++ b/cfg/sequencer.cfg
@@ -57,6 +57,12 @@ dl1ab_config: /software/lstchain/data/lstchain_standard_config.json
 # the MC DL2 uses a different config file, it can be set here.
 dl2_config: /software/lstchain/data/lstchain_standard_config.json
 rf_models: /data/models/prod5/zenith_20deg/20201023_v0.6.3
+dl3_config: /software/lstchain/data/dl3_std_config.json
+
+[IRF]
+mc_gamma: /fefs/aswg/data/mc/DL2/20200629_prod5_trans_80/gamma/zenith_20deg/south_pointing/20210923_v0.7.5_prod5_trans_80_dynamic_cleaning/off0.4deg/dl2_gamma_20deg_180deg_off0.4deg_20210923_v0.7.5_prod5_trans_80_dynamic_cleaning_testing.
+mc_proton: /fefs/aswg/data/mc/DL2/20200629_prod5_trans_80/proton/zenith_20deg/south_pointing/20210923_v0.7.5_prod5_trans_80_dynamic_cleaning/dl2_proton_20deg_180deg_20210923_v0.7.5_prod5_trans_80_dynamic_cleaning_testing.h5
+mc_electron: /fefs/aswg/data/mc/DL2/20200629_prod5_trans_80/electron/zenith_20deg/south_pointing/20210923_v0.7.5_prod5_trans_80_dynamic_cleaning/dl2_electron_20deg_180deg_20210923_v0.7.5_prod5_trans_80_dynamic_cleaning_testing.h5
 
 [SLURM]
 PARTITION_PEDCALIB: short

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - h5py
   - joblib
   - traitlets=5.0
+  - click
   # dev dependencies
   - pre-commit
   - pytest

--- a/osa/configs/datamodel.py
+++ b/osa/configs/datamodel.py
@@ -18,7 +18,9 @@ class Telescope(Night):
 class Source(Telescope):
     def __init__(self):
         super(Source, self).__init__()
-        self.source = None
+        self.source_name = None
+        self.source_ra = None
+        self.source_dec = None
 
 
 class Wobble(Source):

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -72,7 +72,7 @@ def extractsubruns(summary_table):
             sr.runobj.telescope = options.tel_id
             sr.runobj.night = lstdate_to_iso(options.date)
             if not options.test:
-                sr.runobj.source = database.query(
+                sr.runobj.source_name = database.query(
                     obs_id=sr.runobj.run,
                     property_name="DriveControl_SourceName"
                 )

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -67,7 +67,7 @@ def extractsubruns(summary_table):
             # Build run object
             sr.runobj = RunObj()
             sr.runobj.run_str = f"{run_info['run_id']:05d}"
-            sr.runobj.run = run_info["run_id"]
+            sr.runobj.run = int(run_info["run_id"])
             sr.runobj.type = run_info["run_type"]
             sr.runobj.telescope = options.tel_id
             sr.runobj.night = lstdate_to_iso(options.date)

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -159,7 +159,7 @@ def extractsequences(run_list):
 
     for run in run_list:
         # extract the basic info
-        currentsrc = run.source
+        currentsrc = run.source_name
         currentrun = run.run
         currenttype = run.type
 

--- a/osa/scripts/sequencer.py
+++ b/osa/scripts/sequencer.py
@@ -309,7 +309,7 @@ def report_sequences(sequence_list):
             sequence.type,
             sequence.run,
             sequence.subruns,
-            sequence.source,
+            sequence.source_name,
             sequence.action,
             sequence.tries,
             sequence.jobid,

--- a/osa/utils/utils.py
+++ b/osa/utils/utils.py
@@ -341,7 +341,7 @@ def destination_dir(concept, create_dir=True) -> Path:
             / options.prod_id
             / options.dl1_prod_id
         )
-    elif concept == "DL2":
+    elif concept in ["DL2", "DL3"]:
         directory = (
             Path(cfg.get(options.tel_id, concept + "_DIR"))
             / nightdir

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -255,7 +255,7 @@ def main(date_obs, telescope, verbose, simulate, config, local):
 
     # Creating observation index for each source
     for source in source_list:
-        dl3_subdir = dl3_dir / source
+        dl3_subdir = std_cuts_dir / source
 
         cmd3 = cmd_create_index_dl3(dl3_subdir, list_of_job_id)
 

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import subprocess as sp
+from datetime import date, timedelta
+from pathlib import Path
+
+import click
+from astropy.utils import iers
+
+from osa.configs import options
+from osa.configs.config import cfg
+from osa.nightsummary.extract import extractruns, extractsequences, extractsubruns
+from osa.nightsummary.nightsummary import run_summary_table
+from osa.utils.logging import myLogger
+from osa.utils.utils import destination_dir, stringify
+from osa.utils.cliopts import set_default_directory_if_needed, get_prod_id, get_dl2_prod_id
+
+iers.conf.auto_download = False
+
+
+__all__ = ["cmd_create_irf"]
+
+log = myLogger(logging.getLogger())
+
+
+def cmd_create_irf(dl3_dir, mc_gamma, mc_proton, mc_electron, output_irf_file, dl3_config):
+
+    cmd = [
+        "sbatch",
+        "--parsable",
+        "--mem=8GB",
+        "--job-name=irf",
+        f"-D={dl3_dir}",
+        "-o=log/create_irf_%j.log",
+        "lstchain_create_irf_files",
+        "--point-like",
+        f"--input-gamma-dl2={mc_gamma}",
+        f"--input-proton-dl2={mc_proton}",
+        f"--input-electron-dl2={mc_electron}",
+        f"--output-irf-file={output_irf_file}",
+        f"--config={dl3_config}",
+        "--overwrite",
+    ]
+    return cmd
+
+
+def cmd_create_dl3(
+        dl2_file,
+        dl3_dir,
+        run,
+        source_name,
+        source_ra,
+        source_dec,
+        irf,
+        dl3_config,
+        job_irf
+):
+
+    cmd = [
+        "sbatch",
+        "--mem=8GB",
+        "--job-name=dl2dl3",
+        f"--dependency=afterok:{job_irf}",
+        "-D",
+        dl3_dir,
+        "-o",
+        f"log/dl2_dl3_{run:05d}_%j.log",
+        "--parsable",
+        "lstchain_create_dl3_file",
+        f"-d={dl2_file}",
+        f"-o={dl3_dir}",
+        f"--input-irf={irf}",
+        f"--source-name={source_name}",
+        f"--source-ra={source_ra}",
+        f"--source-dec={source_dec}",
+        f"--config={dl3_config}",
+        "--overwrite",
+    ]
+    return cmd
+
+
+def cmd_create_index_dl3(dl3_dir, parent_job_list):
+
+    parent_job_list_str = ",".join(parent_job_list)
+
+    cmd = [
+        "sbatch",
+        "--parsable",
+        "--mem=8GB",
+        "--job-name=dl3_index",
+        f"--dependency=afterok:{parent_job_list_str}",
+        f"-D={dl3_dir}",
+        "-o=log/create_index_dl3_%j.log",
+        "lstchain_create_dl3_index_files",
+        f"-d={dl3_dir}",
+        f"-o={dl3_dir}",
+        "-p=dl3*.fits.gz",
+        "--overwrite",
+    ]
+    return cmd
+
+
+@click.command()
+@click.argument('telescope', type=click.Choice(['LST1', 'LST2']))
+@click.option(
+    '-d',
+    '--date-obs',
+    type=click.DateTime(formats=["%Y_%m_%d"]),
+    default=(date.today()-timedelta(days=1)).strftime("%Y_%m_%d")
+)
+@click.option('-v', '--verbose', is_flag=True)
+@click.option('-s', '--simulate', is_flag=True)
+def main(date_obs, telescope, verbose, simulate):
+    """Produce the IRF and DL3 files tool in a run basis."""
+    if verbose:
+        logging.root.setLevel(logging.DEBUG)
+    else:
+        logging.root.setLevel(logging.INFO)
+
+    options.date = date_obs.strftime('%Y_%m_%d')
+    options.tel_id = telescope
+    options.prod_id = get_prod_id()
+    options.dl2_prod_id = get_dl2_prod_id()
+    options.directory = set_default_directory_if_needed()
+
+    log.info(f"=== Producing IRFs and DL3 files for {telescope} on {date_obs.strftime('%Y-%m-%d')} ===")
+
+    # Build the sequences
+    summary_table = run_summary_table(options.date)
+    subrun_list = extractsubruns(summary_table)
+    run_list = extractruns(subrun_list)
+    sequence_list = extractsequences(run_list)
+
+    # Get the list of source names
+    source_list = []
+    for sequence in sequence_list:
+        sequence.source = "Crab"
+        sequence.source_ra = "83.05deg"
+        sequence.source_dev = "22.02deg"
+        if sequence.source not in source_list:
+            source_list.append(sequence.source)
+
+    log.info(f"List of sources: {source_list}")
+
+    # Create a subdirectory inside the DL3 directory corresponding to the selection cuts
+    log.debug("Creating DL3 directory")
+    dl2_dir = destination_dir("DL2", create_dir=False)
+    dl3_dir = destination_dir("DL3", create_dir=True)
+    std_cuts_dir = dl3_dir / "std_cuts"
+    log_dir = std_cuts_dir / "log"
+    std_cuts_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(exist_ok=True)
+    log.debug(f"DL3 directory: {dl3_dir}")
+
+    # Create a subdirectory for each source
+    for source in source_list:
+        if source is not None:
+            source_dir = std_cuts_dir / source
+            source_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info("Looping over the sequences and running DL2 to DL3 step")
+
+    mc_gamma = cfg.get("IRF", "mc_gamma")
+    mc_proton = cfg.get("IRF", "mc_proton")
+    mc_electron = cfg.get("IRF", "mc_electron")
+    dl3_config = cfg.get("lstchain", "DL3_CONFIG")
+    irf_file = std_cuts_dir / "irf.fits.gz"
+
+    cmd1 = cmd_create_irf(dl3_dir, mc_gamma, mc_proton, mc_electron, irf_file, dl3_config)
+
+    if not simulate:
+        log.info("Producing the IRF")
+        log.debug(stringify(cmd1))
+        job_irf = sp.run(
+            cmd1,
+            encoding="utf-8",
+            capture_output=True,
+            text=True,
+        )
+        job_id_irf = job_irf.stdout.strip()
+        print(job_id_irf)
+
+    else:
+        job_id_irf = None
+        log.debug("Simulate creating IRF")
+
+    list_of_job_id = []
+
+    for sequence in sequence_list:
+
+        if sequence.type == "DATA":
+
+            dl2_file = os.path.join(dl2_dir, f"dl2_LST-1.Run{sequence.run:05d}.h5")
+
+            cmd2 = cmd_create_dl3(
+                dl2_file=dl2_file,
+                dl3_dir=dl3_dir,
+                run=sequence.run,
+                source_name=sequence.source,
+                source_ra=sequence.source_ra,
+                source_dec=sequence.source_dec,
+                irf=irf_file,
+                dl3_config=dl3_config,
+                job_irf=job_id_irf,
+            )
+
+            if not simulate:
+                log.info(f"Producing DL3 file for run {sequence.run:05d}")
+                job_id = sp.run(
+                    cmd2,
+                    encoding="utf-8",
+                    capture_output=True,
+                    text=True,
+                )
+
+                list_of_job_id.append(job_id.stdout.strip())
+
+            else:
+                log.info("Simulate launching scripts")
+
+            log.debug(f"Executing {stringify(cmd1)}")
+
+    cmd3 = cmd_create_index_dl3(dl3_dir, list_of_job_id)
+
+    if not simulate:
+        log.info("Scheduling DL3 index job")
+        sp.run(
+            cmd3,
+            encoding="utf-8",
+            capture_output=True,
+            text=True,
+        )
+    else:
+        log.debug("Simulate creating DL3 index")
+
+    log.debug(f"Executing {stringify(cmd3)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -34,7 +34,7 @@ def cmd_create_irf(cwd, mc_gamma, mc_proton, mc_electron, output_irf_file, dl3_c
     return [
         "sbatch",
         "--parsable",
-        "--mem=8GB",
+        "--mem=6GB",
         "--job-name=irf",
         "-D",
         cwd,
@@ -67,7 +67,7 @@ def cmd_create_dl3(
     log_file = log_dir / f"dl2_to_dl3_Run{run:05d}_{source_name}_%j.log"
     return [
         "sbatch",
-        "--mem=8GB",
+        "--mem=10GB",
         "--job-name=dl2dl3",
         f"--dependency=afterok:{job_irf}",
         "-D",

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -25,6 +25,8 @@ __all__ = [
     "cmd_create_index_dl3",
 ]
 
+log = myLogger(logging.getLogger(__name__))
+
 DEFAULT_CFG = pathlib.Path(__file__).parent / '../../cfg/sequencer.cfg'
 
 
@@ -62,7 +64,7 @@ def cmd_create_dl3(
 ):
     log_dir = dl3_dir / "log"
     log_dir.mkdir(exist_ok=True, parents=True)
-    log_file = log_dir / f"dl2_dl3_{run:05d}_{source_name}_%j.log"
+    log_file = log_dir / f"dl2_to_dl3_Run{run:05d}_{source_name}_%j.log"
     return [
         "sbatch",
         "--mem=8GB",
@@ -128,7 +130,6 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
 @click.option('-s', '--simulate', is_flag=True)
 def main(date_obs, telescope, verbose, simulate, config, local):
     """Produce the IRF and DL3 files tool in a run basis."""
-    log = myLogger(logging.getLogger())
     log.setLevel(logging.INFO)
 
     if verbose:

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -35,7 +35,7 @@ def cmd_create_irf(cwd, mc_gamma, mc_proton, mc_electron, output_irf_file, dl3_c
         "-D",
         cwd,
         "-o",
-        "log/create_irf_%j.log"
+        "log/create_irf_%j.log",
         "lstchain_create_irf_files",
         "--point-like",
         f"--input-gamma-dl2={mc_gamma}",

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -19,9 +19,11 @@ from osa.utils.utils import destination_dir, stringify
 
 iers.conf.auto_download = False
 
-__all__ = ["cmd_create_irf"]
-
-log = myLogger(logging.getLogger())
+__all__ = [
+    "cmd_create_irf",
+    "cmd_create_dl3",
+    "cmd_create_index_dl3",
+]
 
 DEFAULT_CFG = pathlib.Path(__file__).parent / '../../cfg/sequencer.cfg'
 
@@ -126,6 +128,8 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
 @click.option('-s', '--simulate', is_flag=True)
 def main(date_obs, telescope, verbose, simulate, config, local):
     """Produce the IRF and DL3 files tool in a run basis."""
+    log = myLogger(logging.getLogger())
+
     if verbose:
         log.setLevel(logging.DEBUG)
     else:
@@ -242,7 +246,7 @@ def main(date_obs, telescope, verbose, simulate, config, local):
             else:
                 log.info("Simulate launching scripts")
 
-            log.debug(f"Executing {stringify(cmd1)}")
+            log.debug(f"Executing {stringify(cmd2)}")
 
     # Creating observation index for each source
 

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -27,16 +27,15 @@ DEFAULT_CFG = pathlib.Path(__file__).parent / '../../cfg/sequencer.cfg'
 
 
 def cmd_create_irf(cwd, mc_gamma, mc_proton, mc_electron, output_irf_file, dl3_config):
-    log_dir = cwd / "log"
-    log_dir.mkdir(exist_ok=True, parents=True)
-    job_log_file = log_dir / "create_irf_%j.log"
     return [
         "sbatch",
         "--parsable",
         "--mem=8GB",
         "--job-name=irf",
-        f"-D={cwd}",
-        f"-o={job_log_file}",
+        "-D",
+        cwd,
+        "-o",
+        "log/create_irf_%j.log"
         "lstchain_create_irf_files",
         "--point-like",
         f"--input-gamma-dl2={mc_gamma}",
@@ -64,8 +63,10 @@ def cmd_create_dl3(
         "--mem=8GB",
         "--job-name=dl2dl3",
         f"--dependency=afterok:{job_irf}",
-        f"-D={cwd}",
-        f"-o=log/dl2_dl3_{run:05d}_%j.log",
+        "-D",
+        cwd,
+        "-o",
+        f"log/dl2_dl3_{run:05d}_%j.log",
         "--parsable",
         "lstchain_create_dl3_file",
         f"-d={dl2_file}",
@@ -88,8 +89,10 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
         "--mem=8GB",
         "--job-name=dl3_index",
         f"--dependency=afterok:{parent_job_list_str}",
-        f"-D={dl3_dir}",
-        "-o=log/create_index_dl3_%j.log",
+        "-D",
+        dl3_dir,
+        "-o",
+        "log/create_index_dl3_%j.log",
         "lstchain_create_dl3_index_files",
         f"-d={dl3_dir}",
         f"-o={dl3_dir}",

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -27,13 +27,13 @@ log = myLogger(logging.getLogger())
 DEFAULT_CFG = pathlib.Path(__file__).parent / '../../cfg/sequencer.cfg'
 
 
-def cmd_create_irf(dl3_dir, mc_gamma, mc_proton, mc_electron, output_irf_file, dl3_config):
-    cmd = [
+def cmd_create_irf(cwd, mc_gamma, mc_proton, mc_electron, output_irf_file, dl3_config):
+    return [
         "sbatch",
         "--parsable",
         "--mem=8GB",
         "--job-name=irf",
-        f"-D={dl3_dir}",
+        f"-D={cwd}",
         "-o=log/create_irf_%j.log",
         "lstchain_create_irf_files",
         "--point-like",
@@ -44,7 +44,6 @@ def cmd_create_irf(dl3_dir, mc_gamma, mc_proton, mc_electron, output_irf_file, d
         f"--config={dl3_config}",
         "--overwrite",
     ]
-    return cmd
 
 
 def cmd_create_dl3(
@@ -58,15 +57,13 @@ def cmd_create_dl3(
         dl3_config,
         job_irf
 ):
-    cmd = [
+    return [
         "sbatch",
         "--mem=8GB",
         "--job-name=dl2dl3",
         f"--dependency=afterok:{job_irf}",
-        "-D",
-        dl3_dir,
-        "-o",
-        f"log/dl2_dl3_{run:05d}_%j.log",
+        f"-D={dl3_dir}",
+        f"-o=log/dl2_dl3_{run:05d}_%j.log",
         "--parsable",
         "lstchain_create_dl3_file",
         f"-d={dl2_file}",
@@ -78,13 +75,12 @@ def cmd_create_dl3(
         f"--config={dl3_config}",
         "--overwrite",
     ]
-    return cmd
 
 
 def cmd_create_index_dl3(dl3_dir, parent_job_list):
     parent_job_list_str = ",".join(parent_job_list)
 
-    cmd = [
+    return [
         "sbatch",
         "--parsable",
         "--mem=8GB",
@@ -98,7 +94,6 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
         "-p=dl3*.fits.gz",
         "--overwrite",
     ]
-    return cmd
 
 
 @click.command()
@@ -121,9 +116,9 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
 def main(date_obs, telescope, verbose, simulate, config, local):
     """Produce the IRF and DL3 files tool in a run basis."""
     if verbose:
-        logging.root.setLevel(logging.DEBUG)
+        log.setLevel(logging.DEBUG)
     else:
-        logging.root.setLevel(logging.INFO)
+        log.setLevel(logging.INFO)
 
     if local:
         options.test = True
@@ -134,7 +129,7 @@ def main(date_obs, telescope, verbose, simulate, config, local):
     options.dl2_prod_id = get_dl2_prod_id()
     options.directory = set_default_directory_if_needed()
 
-    log.info(f"=== Producing IRFs & DL3 files for {date_obs.strftime('%Y-%m-%d')} ===")
+    log.info(f"=== DL3 stage for {date_obs.strftime('%Y-%m-%d')} ===")
 
     # Build the sequences
     summary_table = run_summary_table(options.date)
@@ -145,13 +140,13 @@ def main(date_obs, telescope, verbose, simulate, config, local):
     # Get the list of source names
     source_list = []
     for sequence in sequence_list:
-        if sequence.source_name not in source_list:
+        if sequence.source_name is not None and sequence.source_name not in source_list:
             source_list.append(sequence.source_name)
 
     log.info(f"List of sources: {source_list}")
 
-    if len(source_list) == 1 and source_list[0] is None:
-        sys.exit("No sources found. Check the access to TCU database. Exiting.")
+    if not source_list:
+        sys.exit("No sources found. Check the access to database. Exiting.")
 
     # Create a subdirectory inside the DL3 directory corresponding to the selection cuts
     log.debug("Creating DL3 directory")
@@ -177,7 +172,14 @@ def main(date_obs, telescope, verbose, simulate, config, local):
     dl3_config = cfg.get("lstchain", "DL3_CONFIG")
     irf_file = std_cuts_dir / "irf.fits.gz"
 
-    cmd1 = cmd_create_irf(dl3_dir, mc_gamma, mc_proton, mc_electron, irf_file, dl3_config)
+    cmd1 = cmd_create_irf(
+        cwd=std_cuts_dir,
+        mc_gamma=mc_gamma,
+        mc_proton=mc_proton,
+        mc_electron=mc_electron,
+        output_irf_file=irf_file,
+        dl3_config=dl3_config,
+    )
 
     if not simulate:
         log.info("Producing the IRF")

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -78,8 +78,8 @@ def cmd_create_dl3(
         f"-o={dl3_dir}",
         f"--input-irf={irf}",
         f"--source-name={source_name}",
-        f"--source-ra={source_ra}",
-        f"--source-dec={source_dec}",
+        f"--source-ra={source_ra}deg",
+        f"--source-dec={source_dec}deg",
         f"--config={dl3_config}",
         "--overwrite",
     ]
@@ -129,11 +129,10 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
 def main(date_obs, telescope, verbose, simulate, config, local):
     """Produce the IRF and DL3 files tool in a run basis."""
     log = myLogger(logging.getLogger())
+    log.setLevel(logging.INFO)
 
     if verbose:
         log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.INFO)
 
     log.info(f"=== DL3 stage for {date_obs.strftime('%Y-%m-%d')} ===")
 
@@ -150,8 +149,6 @@ def main(date_obs, telescope, verbose, simulate, config, local):
     options.prod_id = get_prod_id()
     options.dl2_prod_id = get_dl2_prod_id()
     options.directory = set_default_directory_if_needed()
-
-
 
     # Build the sequences
     summary_table = run_summary_table(options.date)
@@ -256,7 +253,6 @@ def main(date_obs, telescope, verbose, simulate, config, local):
             log.debug(f"Executing {stringify(cmd2)}")
 
     # Creating observation index for each source
-
     for source in source_list:
         dl3_subdir = dl3_dir / source
 

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -150,7 +150,7 @@ def main(date_obs, telescope, verbose, simulate, config, local):
 
     log.info(f"List of sources: {source_list}")
 
-    if len(source_list) and source_list[0] is None:
+    if len(source_list) == 1 and source_list[0] is None:
         sys.exit("No sources found. Check the access to TCU database. Exiting.")
 
     # Create a subdirectory inside the DL3 directory corresponding to the selection cuts

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -135,9 +135,6 @@ def main(date_obs, telescope, verbose, simulate):
     # Get the list of source names
     source_list = []
     for sequence in sequence_list:
-        sequence.source = "Crab"
-        sequence.source_ra = "83.05deg"
-        sequence.source_dev = "22.02deg"
         if sequence.source not in source_list:
             source_list.append(sequence.source)
 

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -109,6 +109,7 @@ def cmd_create_index_dl3(dl3_dir, parent_job_list):
     type=click.DateTime(formats=["%Y_%m_%d"]),
     default=(date.today()-timedelta(days=1)).strftime("%Y_%m_%d")
 )
+@click.option('-c', '--config', type=click.Path(exists=True), default=None)
 @click.option('-v', '--verbose', is_flag=True)
 @click.option('-s', '--simulate', is_flag=True)
 def main(date_obs, telescope, verbose, simulate):

--- a/osa/workflow/dl3.py
+++ b/osa/workflow/dl3.py
@@ -4,7 +4,6 @@ import logging
 import os
 import subprocess as sp
 from datetime import date, timedelta
-from pathlib import Path
 
 import click
 from astropy.utils import iers
@@ -13,9 +12,9 @@ from osa.configs import options
 from osa.configs.config import cfg
 from osa.nightsummary.extract import extractruns, extractsequences, extractsubruns
 from osa.nightsummary.nightsummary import run_summary_table
+from osa.utils.cliopts import set_default_directory_if_needed, get_prod_id, get_dl2_prod_id
 from osa.utils.logging import myLogger
 from osa.utils.utils import destination_dir, stringify
-from osa.utils.cliopts import set_default_directory_if_needed, get_prod_id, get_dl2_prod_id
 
 iers.conf.auto_download = False
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "pydot",
         "pydotplus",
         "psutil",
+        "click"
     ],
     package_data={
         'osa': [

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ entry_points = {
         "provprocess = osa.scripts.provprocess:main",
         "simulate_processing = osa.scripts.simulate_processing:main",
         "calibration_pipeline = osa.scripts.calibration_pipeline:main",
+        "dl3_stage = osa.workflow.dl3:main",
     ]
 }
 


### PR DESCRIPTION
**Usage:** `dl3_stage -d 2021_08_08 -c cfg/sequencer.cfg LST1`

It makes use of the metadata information extracted from the TCU database (source name and RADec coordinates). (WARNING: a run catalog is to be implemented. This would ease the access to metadata information needed for the DL3 tool).

It pipes the lstchain scripts:
- `lstchain_create_irf_files` (once per selection cuts)
- `lstchain_create_dl3_file` (run-wise)
- `lstchain_create_dl3_index_files` (source-wise)

The idea is to end up with the following structure:

```
/fefs/aswg/data/real
├── monitoring
│   ├── RunSummary
│   ├── DrivePositioning
│   └── PixelCalibration
├── DL1
│   └── YYYYMMDD
│       └── vX.Y.Z
│           ├── muons.fits
│           └── tailcut84
│               ├── dl1.h5
│               └── datacheck_dl1.h5
├── DL2
│   └── YYYYMMDD
│       └── vX.Y.Z
│           └── tailcut84
│               └── dl2.h5
└── DL3
    └── YYYYMMDD
        └── vX.Y.Z
            └── tailcut84
                ├── std_cuts
                │   ├── irf_std_cuts.fits
                │   ├── source_name1
                │   │   ├── dl3_LST-1_Run00001.fits
                │   │   ├── dl3_LST-1_Run00002.fits
                │   │   ├── hdu-index.fits.gz
                │   │   └── obs-index.fits.gz
                │   └── source_name2
                │       ├── dl3_LST-1_Run00003.fits
                │       ├── dl3_LST-1_Run00004.fits
                │       ├── hdu-index.fits.gz
                │       └── obs-index.fits.gz
                └── other_cuts

```

Right now this script is intended to be run separately, once closer has been launched and files have been moved to final destinations.

TODO in further PRs: 
- Refactoring.
- DL3 stage should run right after the merging of DL2 files without having to depend on the closer. Sequencer should take care of this analysis step as well through the `datasequence`.
- Implement unit tests.
- Next-day high-level analysis.