### PR TITLE
Fix ci hangs due to coverage 6.3 by pinning to 6.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-cov
+  - coverage=6.2
   - black
   - isort
   - sphinx


### PR DESCRIPTION
See nedbat/coveragepy#1310