### PR TITLE
Script to update source coordinates in RunCatalog files

### DIFF
--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -319,8 +319,8 @@ def run_catalog(run_catalog_dir):
     # delimiter: ','
     # schema: astropy-2.0
     run_id,source_name,source_ra,source_dec
-    1807,Source1,35.543,11.04
-    1808,Source2,115.441,43.98""")
+    1807,Crab,83.543,22.08
+    1808,MadeUpSource,115.441,43.98""")
 
     catalog_file = run_catalog_dir / 'RunCatalog_20200117.ecsv'
     catalog_file.touch()

--- a/osa/nightsummary/set_source_coordinates.py
+++ b/osa/nightsummary/set_source_coordinates.py
@@ -1,8 +1,11 @@
+"""Script to update the source coordinates in the RunCatalog ECSV files."""
+
 import logging
+from pathlib import Path
 
 import click
-from astropy.coordinates import SkyCoord
-from astropy.coordinates import name_resolve
+import numpy as np
+from astropy.coordinates import SkyCoord, name_resolve
 from astropy.table import Table
 
 from osa.utils.logging import myLogger
@@ -15,14 +18,19 @@ log = myLogger(logging.getLogger(__name__))
 @click.option('--source', type=str)
 @click.option('--ra', type=float, help='Right Ascension in degrees')
 @click.option('--dec', type=float, help='Declination in degrees')
-def main(file, source, ra, dec):
-
+def main(
+        file: Path = None,
+        source: str = None,
+        ra: float = np.nan,
+        dec: float = np.nan
+):
+    """Update the source coordinates in the RunCatalog ECSV files."""
     log.setLevel(logging.INFO)
 
     table = Table.read(file)
     table.add_index('run_id')
 
-    for i, run in enumerate(table):
+    for run in table:
         source_name = run['source_name']
         try:
             coords = SkyCoord.from_name(source_name)

--- a/osa/nightsummary/set_source_coordinates.py
+++ b/osa/nightsummary/set_source_coordinates.py
@@ -1,0 +1,47 @@
+import logging
+
+import click
+from astropy.coordinates import SkyCoord
+from astropy.coordinates import name_resolve
+from astropy.table import Table
+
+from osa.utils.logging import myLogger
+
+log = myLogger(logging.getLogger(__name__))
+
+
+@click.command()
+@click.argument('file', type=click.Path(exists=True))
+@click.option('--source', type=str)
+@click.option('--ra', type=float, help='Right Ascension in degrees')
+@click.option('--dec', type=float, help='Declination in degrees')
+def main(file, source, ra, dec):
+
+    log.setLevel(logging.INFO)
+
+    table = Table.read(file)
+    table.add_index('run_id')
+
+    for i, run in enumerate(table):
+        source_name = run['source_name']
+        try:
+            coords = SkyCoord.from_name(source_name)
+            run['source_ra'] = coords.ra.deg
+            run['source_dec'] = coords.dec.deg
+
+        except name_resolve.NameResolveError:
+            if source is None:
+                log.warning(
+                    f'Could not resolve coordinates for {source_name}. '
+                    'Add coordinates through the command line.'
+                )
+            if source_name == source:
+                run['source_ra'] = ra
+                run['source_dec'] = dec
+
+    log.info(f'Updated coordinates in {file}')
+    table.write(file, format='ascii.ecsv', overwrite=True, delimiter=',')
+
+
+if __name__ == '__main__':
+    main()

--- a/osa/nightsummary/tests/test_source_coordinates.py
+++ b/osa/nightsummary/tests/test_source_coordinates.py
@@ -1,3 +1,4 @@
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
@@ -23,7 +24,7 @@ def test_source_coordinates(run_catalog):
 
     # Check new coordinates
     crab_coords = SkyCoord.from_name('Crab')
-    assert table[table['source_name'] == 'Crab']['source_ra'] == crab_coords.ra.deg
-    assert table[table['source_name'] == 'Crab']['source_dec'] == crab_coords.dec.deg
-    assert table[table['source_name'] == 'MadeUpSource']['source_ra'] == 31.22
-    assert table[table['source_name'] == 'MadeUpSource']['source_dec'] == 52.95
+    assert np.isclose(table[table['source_name'] == 'Crab']['source_ra'], crab_coords.ra.deg)
+    assert np.isclose(table[table['source_name'] == 'Crab']['source_dec'], crab_coords.dec.deg)
+    assert np.isclose(table[table['source_name'] == 'MadeUpSource']['source_ra'], 31.22)
+    assert np.isclose(table[table['source_name'] == 'MadeUpSource']['source_dec'], 52.95)

--- a/osa/nightsummary/tests/test_source_coordinates.py
+++ b/osa/nightsummary/tests/test_source_coordinates.py
@@ -1,0 +1,29 @@
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+
+from osa.scripts.tests.test_osa_scripts import run_program
+
+
+def test_source_coordinates(run_catalog):
+    assert run_catalog.exists()
+
+    output = run_program(
+        'source_coordinates',
+        '--source',
+        'MadeUpSource',
+        '--ra',
+        '31.22',
+        '--dec',
+        '52.95',
+        str(run_catalog)
+    )
+
+    assert output.returncode == 0
+    table = Table.read(run_catalog)
+
+    # Check new coordinates
+    crab_coords = SkyCoord.from_name('Crab')
+    assert table[table['source_name'] == 'Crab']['source_ra'] == crab_coords.ra.deg
+    assert table[table['source_name'] == 'Crab']['source_dec'] == crab_coords.dec.deg
+    assert table[table['source_name'] == 'MadeUpSource']['source_ra'] == 31.22
+    assert table[table['source_name'] == 'MadeUpSource']['source_dec'] == 52.95

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -122,10 +122,10 @@ def test_simulated_sequencer(
     assert rc.stdout == dedent(
         f"""\
         ================================== Starting sequencer.py at {now} UTC for LST, Telescope: LST1, Night: 2020_01_17 ==================================
-        Tel   Seq  Parent  Type      Run   Subruns  Source   Action  Tries  JobID  State  CPU_time  Exit  DL1%  MUONS%  DL1AB%  DATACHECK%  DL2%  
-        LST1    0  None    PEDCALIB  1805  5        None     None    None   None   None   None      None  None  None    None    None        None  
-        LST1    1       0  DATA      1807  11       Source1  None    None   None   None   None      None     0       0       0           0     0  
-        LST1    2       0  DATA      1808  9        Source2  None    None   None   None   None      None     0       0       0           0     0  
+        Tel   Seq  Parent  Type      Run   Subruns  Source        Action  Tries  JobID  State  CPU_time  Exit  DL1%  MUONS%  DL1AB%  DATACHECK%  DL2%  
+        LST1    0  None    PEDCALIB  1805  5        None          None    None   None   None   None      None  None  None    None    None        None  
+        LST1    1       0  DATA      1807  11       Crab          None    None   None   None   None      None     0       0       0           0     0  
+        LST1    2       0  DATA      1808  9        MadeUpSource  None    None   None   None   None      None     0       0       0           0     0  
         """)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ entry_points = {
         "simulate_processing = osa.scripts.simulate_processing:main",
         "calibration_pipeline = osa.scripts.calibration_pipeline:main",
         "dl3_stage = osa.workflow.dl3:main",
+        "source_coordinates = osa.nightsummary.set_source_coordinates:main",
     ]
 }
 


### PR DESCRIPTION
Currently, coordinates of the target are obtained from TCU database but contain wobble offsets. This script updates the coordinates based on the name. If not available, coordinates must be manually given via the command line.