### PR TITLE
Remove unused longterm script from cfg

### DIFF
--- a/cfg/sequencer.cfg
+++ b/cfg/sequencer.cfg
@@ -59,9 +59,9 @@ rf_models: /data/models/prod5/zenith_20deg/20201023_v0.6.3
 dl3_config: /software/lstchain/data/dl3_std_config.json
 
 [IRF]
-mc_gamma: /path/to/gamma_mc_testing.h5
-mc_proton: /path/to/proton_mc_testing.h5
-mc_electron: /path/to/electron_mc_testing.h5
+mc_gamma: /path/to/DL2/gamma_mc_testing.h5
+mc_proton: /path/to/DL2/proton_mc_testing.h5
+mc_electron: /path/to/DL2/electron_mc_testing.h5
 
 [SLURM]
 PARTITION_PEDCALIB: short

--- a/cfg/sequencer.cfg
+++ b/cfg/sequencer.cfg
@@ -5,10 +5,10 @@
 
 [LST1]
 # Directories to replicate the LST1 directory tree.
-# The BASE and MONITORING need to be set by the user.
+# The BASE directory is to be set by the user.
 BASE: test_osa/test_files0
-MONITORING: %(BASE)s/monitoring
 # The directories below can be left untouched.
+MONITORING: %(BASE)s/monitoring
 R0_DIR: %(BASE)s/R0
 DRIVE_DIR: %(MONITORING)s/DrivePositioning
 RUN_SUMMARY_DIR: %(MONITORING)s/RunSummary
@@ -48,9 +48,6 @@ dl1ab: lstchain_dl1ab
 check_dl1: lstchain_check_dl1
 dl1_to_dl2: lstchain_dl1_to_dl2
 
-# Path to longterm dl1 script
-longterm_check: lstchain_longterm_dl1_check
-
 # To be set by the user
 store_image_dl1ab: True
 merge_dl1_datacheck: True
@@ -62,9 +59,9 @@ rf_models: /data/models/prod5/zenith_20deg/20201023_v0.6.3
 dl3_config: /software/lstchain/data/dl3_std_config.json
 
 [IRF]
-mc_gamma: /fefs/aswg/data/mc/DL2/20200629_prod5_trans_80/gamma/zenith_20deg/south_pointing/20210923_v0.7.5_prod5_trans_80_dynamic_cleaning/off0.4deg/dl2_gamma_20deg_180deg_off0.4deg_20210923_v0.7.5_prod5_trans_80_dynamic_cleaning_testing.
-mc_proton: /fefs/aswg/data/mc/DL2/20200629_prod5_trans_80/proton/zenith_20deg/south_pointing/20210923_v0.7.5_prod5_trans_80_dynamic_cleaning/dl2_proton_20deg_180deg_20210923_v0.7.5_prod5_trans_80_dynamic_cleaning_testing.h5
-mc_electron: /fefs/aswg/data/mc/DL2/20200629_prod5_trans_80/electron/zenith_20deg/south_pointing/20210923_v0.7.5_prod5_trans_80_dynamic_cleaning/dl2_electron_20deg_180deg_20210923_v0.7.5_prod5_trans_80_dynamic_cleaning_testing.h5
+mc_gamma: /path/to/gamma_mc_testing.h5
+mc_proton: /path/to/proton_mc_testing.h5
+mc_electron: /path/to/electron_mc_testing.h5
 
 [SLURM]
 PARTITION_PEDCALIB: short


### PR DESCRIPTION
Since it is directly defined in the code (see #104)