### PR TITLE
Use systematic correction factor file in r0 to dl1 script

### DIFF
--- a/cfg/sequencer.cfg
+++ b/cfg/sequencer.cfg
@@ -18,6 +18,7 @@ CALIB_BASE_DIR: %(MONITORING)s/PixelCalibration/LevelA
 CALIB_DIR: %(CALIB_BASE_DIR)s/calibration
 PEDESTAL_DIR: %(CALIB_BASE_DIR)s/drs4_baseline
 TIMECALIB_DIR: %(CALIB_BASE_DIR)s/drs4_time_sampling_from_FF
+SYSTEMATIC_DIR: %(CALIB_BASE_DIR)s/ffactor_systematics
 DL1_DIR: %(BASE)s/DL1
 DL1AB_DIR: %(BASE)s/DL1
 MUON_DIR: %(BASE)s/DL1

--- a/osa/configs/datamodel.py
+++ b/osa/configs/datamodel.py
@@ -99,6 +99,8 @@ class SequenceData(Sequence):
         self.calibration = None
         self.pedestal = None
         self.drive = None
+        self.time_calibration = None
+        self.systematic_correction = None
         self.dl1status = None
         self.dl1abstatus = None
         self.muonstatus = None

--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -100,6 +100,21 @@ def drs4_time_calibration_files(calibration_base_dir):
 
 
 @pytest.fixture(scope="session")
+def systematic_correction_files(calibration_base_dir):
+    directory = calibration_base_dir / "ffactor_systematics"
+    directory1 = directory / "20200725" / "pro"
+    directory2 = directory / "20201110" / "pro"
+    directory1.mkdir(parents=True, exist_ok=True)
+    directory2.mkdir(parents=True, exist_ok=True)
+    file1 = directory1 / "ffactor_systematics_20200725.h5"
+    file2 = directory2 / "ffactor_systematics_20201110.h5"
+    sys_corr_file_list = [file1, file2]
+    for file in sys_corr_file_list:
+        file.touch()
+    return sys_corr_file_list
+
+
+@pytest.fixture(scope="session")
 def running_analysis_dir(base_test_dir):
     analysis_dir = base_test_dir / "running_analysis" / nightdir / prod_id
     analysis_dir.mkdir(parents=True, exist_ok=True)
@@ -143,21 +158,6 @@ def calibration_file(calibration_dir):
     calib_file = calibration_dir / "calibration_filters_52.Run01805.0000.h5"
     calib_file.touch()
     return calib_file
-
-
-@pytest.fixture(scope="session")
-def calibration_file_log(calibration_dir):
-    """Mock calibration files for testing."""
-    calib_log_dir = calibration_dir / "log"
-    calib_log_dir.mkdir(parents=True, exist_ok=True)
-    calib_log = calib_log_dir / "calibration_filters_52.Run01805.0000.log"
-    calib_log.touch()
-    calib_log.write_text(
-        '  "systematic_correction_path": '
-        '"/path/to/PixelCalibration/LevelA/ffactor_systematics/'
-        '20200117/v0.1.0/no_sys_corrected_calibration_scan_fit_20200101.0000.h5",'
-    )
-    return calib_log
 
 
 @pytest.fixture(scope="session")
@@ -231,7 +231,7 @@ def sequence_list(
         running_analysis_dir,
         run_summary,
         drs4_time_calibration_files,
-        calibration_file_log,
+        systematic_correction_files,
         r0_data,
 ):
     """Creates a sequence list from a run summary file."""
@@ -242,7 +242,8 @@ def sequence_list(
     for file in drs4_time_calibration_files:
         assert file.exists()
 
-    assert calibration_file_log.exists()
+    for file in systematic_correction_files:
+        assert file.exists()
 
     for file in r0_data:
         assert file.exists()
@@ -259,14 +260,18 @@ def sequence_file_list(
         run_summary_file,
         run_catalog,
         drs4_time_calibration_files,
-        calibration_file_log,
+        systematic_correction_files,
         r0_data
 ):
     for r0_file in r0_data:
         assert r0_file.exists()
+
     for file in drs4_time_calibration_files:
         assert file.exists()
-    assert calibration_file_log.exists()
+
+    for file in systematic_correction_files:
+        assert file.exists()
+
     assert run_summary_file.exists()
     assert run_catalog.exists()
 

--- a/osa/job.py
+++ b/osa/job.py
@@ -300,7 +300,7 @@ def get_systematic_correction_file(date: str) -> Path:
     # Search for the first sys correction file before the run, if nothing before,
     # use the first found
     dir_list = sorted(sys_dir.rglob('*/pro/ffactor_systematics*'))
-    if len(dir_list) == 0:
+    if not dir_list:
         raise IOError(
             f"No systematic correction file found for production pro in {sys_dir}\n"
         )

--- a/osa/job.py
+++ b/osa/job.py
@@ -301,6 +301,8 @@ def get_systematic_correction_file(run_id: int) -> Path:
         for line in logfile.readlines():
             if '"systematic_correction_path": ' in line:
                 return Path(line.split('"')[3]).resolve()
+            else:
+                raise IOError("No systematic correction file found in log")
 
 
 def get_drs4_pedestal_file(run_id: int) -> Path:

--- a/osa/job.py
+++ b/osa/job.py
@@ -45,6 +45,7 @@ __all__ = [
     "get_time_calibration_file",
     "get_calibration_file",
     "get_drs4_pedestal_file",
+    "get_systematic_correction_file"
 ]
 
 TAB = "\t".expandtabs(4)

--- a/osa/provenance/config/definition.yaml
+++ b/osa/provenance/config/definition.yaml
@@ -145,6 +145,11 @@ activities:
               entityName: TimeCalibrationFile
               value: TimeCalibrationFile
               # filepath: /fefs/aswg/data/real/calibration/20191124/v00/time_calibration.Run1625.0000.hdf5
+            - role: "Systematic correction factor file"
+              description: "Systematic correction factor file"
+              entityName: SystematicCorrectionFile
+              value: SystematicCorrectionFile
+              # filepath: /fefs/aswg/data/real/monitoring/PixelCalibration/LevelA/ffactor_systematics/20210514/v0.8.2/no_sys_corrected_calibration_scan_fit_20210514.0000.h5
             - role: "Pointing file"
               description: "Pointing filename for DL1"
               entityName: PointingFile

--- a/osa/provenance/utils.py
+++ b/osa/provenance/utils.py
@@ -95,17 +95,19 @@ def parse_variables(class_instance):
         # calibrationfile   [0] .../20200218/pro/calibration_filters_52.Run02006.0000.h5
         # pedestalfile      [1] .../20200218/pro/drs4_pedestal.Run02005.0000.h5
         # timecalibfile     [2] .../20191124/pro/time_calibration.Run01625.0000.h5
-        # drivefile         [3] .../DrivePositioning/drive_log_20_02_18.txt
-        # runsummaryfile    [4] .../RunSummary/RunSummary_20200101.ecsv
-        # run_str           [5] 02006.0000
+        # systematic_corr   [3] .../20200101/pro/no_sys_corrected_calibration_scan_fit_20210514.0000.h5
+        # drivefile         [4] .../DrivePositioning/drive_log_20_02_18.txt
+        # runsummaryfile    [5] .../RunSummary/RunSummary_20200101.ecsv
+        # run_str           [6] 02006.0000
 
-        class_instance.ObservationRun = class_instance.args[5].split(".")[0]
+        run_subrun_id = class_instance.args[6]
+        class_instance.ObservationRun = run_subrun_id.split(".")[0]
         # use realpath to resolve symbolic links and return abspath
         calibration_file = os.path.realpath(class_instance.args[0])
         pedestal_file = os.path.realpath(class_instance.args[1])
         timecalibration_file = os.path.realpath(class_instance.args[2])
         class_instance.R0SubrunDataset = os.path.realpath(
-            f"{raw_dir}/{flat_date}/LST-1.1.Run{class_instance.args[5]}.fits.fz"
+            f"{raw_dir}/{flat_date}/LST-1.1.Run{run_subrun_id}.fits.fz"
         )
         class_instance.CoefficientsCalibrationFile = calibration_file
         class_instance.PedestalFile = pedestal_file
@@ -113,10 +115,10 @@ def parse_variables(class_instance):
         class_instance.PointingFile = os.path.realpath(class_instance.args[3])
         class_instance.RunSummaryFile = os.path.realpath(class_instance.args[4])
         class_instance.DL1SubrunDataset = os.path.realpath(
-            f"{outdir_dl1}/dl1_LST-1.Run{class_instance.args[5]}.h5"
+            f"{outdir_dl1}/dl1_LST-1.Run{run_subrun_id}.h5"
         )
         class_instance.MuonsSubrunDataset = os.path.realpath(
-            f"{muon_dir}/muons_LST-1.Run{class_instance.args[5]}.fits"
+            f"{muon_dir}/muons_LST-1.Run{run_subrun_id}.fits"
         )
 
     if class_instance.__name__ == "dl1ab":

--- a/osa/provenance/utils.py
+++ b/osa/provenance/utils.py
@@ -106,12 +106,14 @@ def parse_variables(class_instance):
         calibration_file = os.path.realpath(class_instance.args[0])
         pedestal_file = os.path.realpath(class_instance.args[1])
         timecalibration_file = os.path.realpath(class_instance.args[2])
+        systematic_correction_file = os.path.realpath(class_instance.args[3])
         class_instance.R0SubrunDataset = os.path.realpath(
             f"{raw_dir}/{flat_date}/LST-1.1.Run{run_subrun_id}.fits.fz"
         )
         class_instance.CoefficientsCalibrationFile = calibration_file
         class_instance.PedestalFile = pedestal_file
         class_instance.TimeCalibrationFile = timecalibration_file
+        class_instance.SystematicCorrectionFile = systematic_correction_file
         class_instance.PointingFile = os.path.realpath(class_instance.args[3])
         class_instance.RunSummaryFile = os.path.realpath(class_instance.args[4])
         class_instance.DL1SubrunDataset = os.path.realpath(

--- a/osa/scripts/datasequence.py
+++ b/osa/scripts/datasequence.py
@@ -21,6 +21,7 @@ def data_sequence(
         calibration_file: Path,
         pedestal_file: Path,
         time_calibration_file: Path,
+        systematic_correction_file: Path,
         drive_file: Path,
         run_summary: Path,
         run_str: str
@@ -33,6 +34,7 @@ def data_sequence(
     calibration_file: pathlib.Path
     pedestal_file: pathlib.Path
     time_calibration_file: pathlib.Path
+    systematic_correction_file: pathlib.Path
     drive_file: pathlib.Path
     run_summary: pathlib.Path
     run_str: str
@@ -52,6 +54,7 @@ def data_sequence(
             calibration_file,
             pedestal_file,
             time_calibration_file,
+            systematic_correction_file,
             drive_file,
             run_summary,
             run_str,
@@ -99,6 +102,7 @@ def r0_to_dl1(
         calibration_file: Path,
         pedestal_file: Path,
         time_calibration_file: Path,
+        systematic_correction_file: Path,
         drive_file: Path,
         run_summary: Path,
         run_str: str,
@@ -114,6 +118,7 @@ def r0_to_dl1(
     calibration_file: pathlib.Path
     pedestal_file: pathlib.Path
     time_calibration_file: pathlib.Path
+    systematic_correction_file: pathlib.Path
     drive_file: pathlib.Path
     run_summary: : pathlib.Path
         Path to the run summary file
@@ -138,6 +143,7 @@ def r0_to_dl1(
         f"--pedestal-file={pedestal_file}",
         f"--calibration-file={calibration_file}",
         f"--time-calibration-file={time_calibration_file}",
+        f"--systematic-correction-file={systematic_correction_file}",
         f"--pointing-file={drive_file}",
         f"--run-summary-path={run_summary}",
     ]
@@ -304,6 +310,7 @@ def main():
         calibration_file,
         drs4_ped_file,
         time_calibration_file,
+        systematic_correction_file,
         drive_log_file,
         run_summary_file,
         run_number,
@@ -319,6 +326,7 @@ def main():
         calibration_file,
         drs4_ped_file,
         time_calibration_file,
+        systematic_correction_file,
         drive_log_file,
         run_summary_file,
         run_number,

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -89,16 +89,16 @@ def test_simulate_processing(
 
     with open(json_file_dl1) as file:
         dl1 = yaml.safe_load(file)
-    assert len(dl1["entity"]) == 15
+    assert len(dl1["entity"]) == 26
     assert len(dl1["activity"]) == 4
-    assert len(dl1["used"]) == 12
+    assert len(dl1["used"]) == 23
     assert len(dl1["wasGeneratedBy"]) == 7
 
     with open(json_file_dl2) as file:
         dl2 = yaml.safe_load(file)
-    assert len(dl2["entity"]) == 24
+    assert len(dl2["entity"]) == 35
     assert len(dl2["activity"]) == 6
-    assert len(dl2["used"]) == 20
+    assert len(dl2["used"]) == 31
     assert len(dl2["wasGeneratedBy"]) == 12
 
     rc = run_program("simulate_processing", "-p")

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -54,7 +54,7 @@ def test_all_help(script):
 
 def test_simulate_processing(
         drs4_time_calibration_files,
-        calibration_file_log,
+        systematic_correction_files,
         run_summary_file,
         r0_data
 ):
@@ -62,7 +62,8 @@ def test_simulate_processing(
     for file in drs4_time_calibration_files:
         assert file.exists()
 
-    assert calibration_file_log.exists()
+    for file in systematic_correction_files:
+        assert file.exists()
 
     for r0_file in r0_data:
         assert r0_file.exists()
@@ -111,21 +112,27 @@ def test_simulate_processing(
 
 def test_simulated_sequencer(
         drs4_time_calibration_files,
-        calibration_file_log,
+        systematic_correction_files,
         run_summary_file,
         run_catalog,
         r0_data
 ):
     assert run_summary_file.exists()
     assert run_catalog.exists()
+
     for r0_file in r0_data:
         assert r0_file.exists()
+
     for file in drs4_time_calibration_files:
         assert file.exists()
-    assert calibration_file_log.exists()
+
+    for file in systematic_correction_files:
+        assert file.exists()
+
     rc = run_program(
         "sequencer", "-c", "cfg/sequencer.cfg", "-d", "2020_01_17", "-s", "-t", "LST1"
     )
+
     assert rc.returncode == 0
     now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M")
     assert rc.stdout == dedent(

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -52,10 +52,17 @@ def test_all_help(script):
     run_program(script, "--help")
 
 
-def test_simulate_processing(drs4_time_calibration_files, run_summary_file, r0_data):
+def test_simulate_processing(
+        drs4_time_calibration_files,
+        calibration_file_log,
+        run_summary_file,
+        r0_data
+):
 
     for file in drs4_time_calibration_files:
         assert file.exists()
+
+    assert calibration_file_log.exists()
 
     for r0_file in r0_data:
         assert r0_file.exists()
@@ -104,6 +111,7 @@ def test_simulate_processing(drs4_time_calibration_files, run_summary_file, r0_d
 
 def test_simulated_sequencer(
         drs4_time_calibration_files,
+        calibration_file_log,
         run_summary_file,
         run_catalog,
         r0_data
@@ -114,6 +122,7 @@ def test_simulated_sequencer(
         assert r0_file.exists()
     for file in drs4_time_calibration_files:
         assert file.exists()
+    assert calibration_file_log.exists()
     rc = run_program(
         "sequencer", "-c", "cfg/sequencer.cfg", "-d", "2020_01_17", "-s", "-t", "LST1"
     )
@@ -206,6 +215,7 @@ def test_datasequence(running_analysis_dir):
     drs4_file = "drs4_pedestal.Run00001.0000.fits"
     calib_file = "calibration.Run00002.0000.hdf5"
     timecalib_file = "time_calibration.Run00002.0000.hdf5"
+    systematic_correction_file = "no_sys_corrected_calibration_scan_fit_20210514.0000.h5"
     drive_file = "drive_log_20200117.txt"
     runsummary_file = "RunSummary_20200117.ecsv"
     prod_id = "v0.1.0"
@@ -222,6 +232,7 @@ def test_datasequence(running_analysis_dir):
         f"--drs4-pedestal-file={drs4_file}",
         f"--pedcal-file={calib_file}",
         f"--time-calib-file={timecalib_file}",
+        f"--systematic-correction-file={systematic_correction_file}",
         f"--drive-file={drive_file}",
         f"--run-summary={runsummary_file}",
         run_number,

--- a/osa/tests/test_jobs.py
+++ b/osa/tests/test_jobs.py
@@ -171,7 +171,7 @@ def test_create_job_template_scheduler(
             '--drs4-pedestal-file={drs4_baseline_file}',
             '--time-calib-file={drs4_time_calibration_files[0]}',
             '--pedcal-file={calibration_file}',
-            '--systematic-correction-file=/path/to/PixelCalibration/LevelA/ffactor_systematics/20200117/v0.1.0/no_sys_corrected_calibration_scan_fit_20200101.0000.h5',
+            '--systematic-correction-file={Path.cwd()}/test_osa/test_files0/monitoring/PixelCalibration/LevelA/ffactor_systematics/20200725/pro/ffactor_systematics_20200725.h5',
             '--drive-file={Path.cwd()}/test_osa/test_files0/monitoring/DrivePositioning/drive_log_20_01_17.txt',
             '--run-summary={run_summary_file}',
             '01807.{{0}}'.format(str(subruns).zfill(4)),
@@ -188,7 +188,7 @@ def test_create_job_template_local(
         drs4_time_calibration_files,
         drs4_baseline_file,
         calibration_file,
-        calibration_file_log,
+        systematic_correction_files,
         run_summary_file,
         r0_data
 ):
@@ -198,7 +198,8 @@ def test_create_job_template_local(
     for file in drs4_time_calibration_files:
         assert file.exists()
 
-    assert calibration_file_log.exists()
+    for file in systematic_correction_files:
+        assert file.exists()
 
     for file in r0_data:
         assert file.exists()
@@ -227,7 +228,7 @@ def test_create_job_template_local(
             '--drs4-pedestal-file={drs4_baseline_file}',
             '--time-calib-file={drs4_time_calibration_files[0]}',
             '--pedcal-file={calibration_file}',
-            '--systematic-correction-file=/path/to/PixelCalibration/LevelA/ffactor_systematics/20200117/v0.1.0/no_sys_corrected_calibration_scan_fit_20200101.0000.h5',
+            '--systematic-correction-file={Path.cwd()}/test_osa/test_files0/monitoring/PixelCalibration/LevelA/ffactor_systematics/20200725/pro/ffactor_systematics_20200725.h5',
             '--drive-file={Path.cwd()}/test_osa/test_files0/monitoring/DrivePositioning/drive_log_20_01_17.txt',
             '--run-summary={run_summary_file}',
             '01807.{{0}}'.format(str(subruns).zfill(4)),

--- a/osa/tests/test_jobs.py
+++ b/osa/tests/test_jobs.py
@@ -71,8 +71,8 @@ def test_scheduler_env_variables(sequence_list, running_analysis_dir):
         '#SBATCH --job-name=LST1_01805',
         '#SBATCH --cpus-per-task=1',
         f'#SBATCH --chdir={running_analysis_dir}',
-        '#SBATCH --output=log/slurm_01805.%4a_%A.out',
-        '#SBATCH --error=log/slurm_01805.%4a_%A.err',
+        '#SBATCH --output=log/Run01805.%4a_jobid_%A.out',
+        '#SBATCH --error=log/Run01805.%4a_jobid_%A.err',
         '#SBATCH --partition=short',
         '#SBATCH --mem-per-cpu=3GB'
     ]
@@ -83,8 +83,8 @@ def test_scheduler_env_variables(sequence_list, running_analysis_dir):
         '#SBATCH --job-name=LST1_01807',
         '#SBATCH --cpus-per-task=1',
         f'#SBATCH --chdir={running_analysis_dir}',
-        '#SBATCH --output=log/slurm_01807.%4a_%A.out',
-        '#SBATCH --error=log/slurm_01807.%4a_%A.err',
+        '#SBATCH --output=log/Run01807.%4a_jobid_%A.out',
+        '#SBATCH --error=log/Run01807.%4a_jobid_%A.err',
         '#SBATCH --array=0-10',
         '#SBATCH --partition=long',
         '#SBATCH --mem-per-cpu=16GB'
@@ -103,8 +103,8 @@ def test_job_header_template(sequence_list, running_analysis_dir):
     #SBATCH --job-name=LST1_01805
     #SBATCH --cpus-per-task=1
     #SBATCH --chdir={running_analysis_dir}
-    #SBATCH --output=log/slurm_01805.%4a_%A.out
-    #SBATCH --error=log/slurm_01805.%4a_%A.err
+    #SBATCH --output=log/Run01805.%4a_jobid_%A.out
+    #SBATCH --error=log/Run01805.%4a_jobid_%A.err
     #SBATCH --partition=short
     #SBATCH --mem-per-cpu=3GB""")
     assert header == output_string1
@@ -118,8 +118,8 @@ def test_job_header_template(sequence_list, running_analysis_dir):
     #SBATCH --job-name=LST1_01807
     #SBATCH --cpus-per-task=1
     #SBATCH --chdir={running_analysis_dir}
-    #SBATCH --output=log/slurm_01807.%4a_%A.out
-    #SBATCH --error=log/slurm_01807.%4a_%A.err
+    #SBATCH --output=log/Run01807.%4a_jobid_%A.out
+    #SBATCH --error=log/Run01807.%4a_jobid_%A.err
     #SBATCH --array=0-10
     #SBATCH --partition=long
     #SBATCH --mem-per-cpu=16GB""")
@@ -143,8 +143,8 @@ def test_create_job_template_scheduler(
     #SBATCH --job-name=LST1_01807
     #SBATCH --cpus-per-task=1
     #SBATCH --chdir={Path.cwd()}/test_osa/test_files0/running_analysis/20200117/v0.1.0
-    #SBATCH --output=log/slurm_01807.%4a_%A.out
-    #SBATCH --error=log/slurm_01807.%4a_%A.err
+    #SBATCH --output=log/Run01807.%4a_jobid_%A.out
+    #SBATCH --error=log/Run01807.%4a_jobid_%A.err
     #SBATCH --array=0-10
     #SBATCH --partition={cfg.get('SLURM', 'PARTITION_DATA')}
     #SBATCH --mem-per-cpu={cfg.get('SLURM', 'MEMSIZE_DATA')}
@@ -171,10 +171,9 @@ def test_create_job_template_scheduler(
             '--drs4-pedestal-file={drs4_baseline_file}',
             '--time-calib-file={drs4_time_calibration_files[0]}',
             '--pedcal-file={calibration_file}',
+            '--systematic-correction-file=/path/to/PixelCalibration/LevelA/ffactor_systematics/20200117/v0.1.0/no_sys_corrected_calibration_scan_fit_20200101.0000.h5',
             '--drive-file={Path.cwd()}/test_osa/test_files0/monitoring/DrivePositioning/drive_log_20_01_17.txt',
             '--run-summary={run_summary_file}',
-            '--stderr=log/sequence_LST1_01807.{{0}}_{{1}}.err'.format(str(subruns).zfill(4), str(job_id)),
-            '--stdout=log/sequence_LST1_01807.{{0}}_{{1}}.out'.format(str(subruns).zfill(4), str(job_id)),
             '01807.{{0}}'.format(str(subruns).zfill(4)),
             'LST1'
         ])
@@ -189,10 +188,21 @@ def test_create_job_template_local(
         drs4_time_calibration_files,
         drs4_baseline_file,
         calibration_file,
-        run_summary_file
+        calibration_file_log,
+        run_summary_file,
+        r0_data
 ):
     """Check the job file in local mode (assuming no scheduler)."""
     from osa.job import create_job_template
+
+    for file in drs4_time_calibration_files:
+        assert file.exists()
+
+    assert calibration_file_log.exists()
+
+    for file in r0_data:
+        assert file.exists()
+
     options.test = True
     options.simulate = False
     content = create_job_template(sequence_list[1], get_content=True)
@@ -217,6 +227,7 @@ def test_create_job_template_local(
             '--drs4-pedestal-file={drs4_baseline_file}',
             '--time-calib-file={drs4_time_calibration_files[0]}',
             '--pedcal-file={calibration_file}',
+            '--systematic-correction-file=/path/to/PixelCalibration/LevelA/ffactor_systematics/20200117/v0.1.0/no_sys_corrected_calibration_scan_fit_20200101.0000.h5',
             '--drive-file={Path.cwd()}/test_osa/test_files0/monitoring/DrivePositioning/drive_log_20_01_17.txt',
             '--run-summary={run_summary_file}',
             '01807.{{0}}'.format(str(subruns).zfill(4)),

--- a/osa/utils/cliopts.py
+++ b/osa/utils/cliopts.py
@@ -343,6 +343,11 @@ def data_sequence_argparser():
         help="Path of the time calibration file"
     )
     parser.add_argument(
+        "--systematic-correction-file",
+        type=Path,
+        help="Path of the systematic correction factor file"
+    )
+    parser.add_argument(
         "--drive-file",
         type=Path,
         help="Path of drive log file with pointing information"
@@ -398,6 +403,7 @@ def data_sequence_cli_parsing():
         opts.pedcal_file,
         opts.drs4_pedestal_file,
         opts.time_calib_file,
+        opts.systematic_correction_file,
         opts.drive_file,
         opts.run_summary,
         opts.run_number,


### PR DESCRIPTION
Closes #96 

- [x] Implement a function to look for the systematic correction file path used to produce the calibration file to be employed for data processing (this information is in the calibration log and in principle in the metadata info in the calibration h5 file itself). However, for the moment the searching for the systematic correction file is done similarly to how it is done in [lstchain/scripts/onsite/onsite_create_calibration_file.py](https://github.com/cta-observatory/cta-lstchain/blob/d3e5503709dd8dd00d42cc2c566749b4c81fad11/lstchain/scripts/onsite/onsite_create_calibration_file.py#L230-L239). The reason is that at the moment of launching OSA sequencer, the calibration file is not yet produced.
- [x] Update sequence object in datamodel.py
- [x] Update lstchain_data_r0_to_dl1 command in job.py
- [ ] Add systematic correction file to provenance
- [x] Add systematic correction file argument to datasequence.py and use it to build the r0dl1 command
- [x] Update tests