### PR TITLE
Use pedestal ids files in r0 to dl1 script provided they exists

### DIFF
--- a/cfg/sequencer.cfg
+++ b/cfg/sequencer.cfg
@@ -13,6 +13,7 @@ R0_DIR: %(BASE)s/R0
 DRIVE_DIR: %(MONITORING)s/DrivePositioning
 RUN_SUMMARY_DIR: %(MONITORING)s/RunSummary
 RUN_CATALOG: %(MONITORING)s/RunCatalog
+PEDESTAL_FINDER_DIR: %(BASE)s/auxiliary/PedestalFinder
 ANALYSIS_DIR: %(BASE)s/running_analysis
 CALIB_BASE_DIR: %(MONITORING)s/PixelCalibration/LevelA
 CALIB_DIR: %(CALIB_BASE_DIR)s/calibration

--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -227,12 +227,23 @@ def run_summary(run_summary_file):
 
 
 @pytest.fixture(scope="session")
+def pedestal_ids_file(base_test_dir):
+    """Mock pedestal ids file for testing."""
+    pedestal_ids_dir = base_test_dir / "auxiliary/PedestalFinder/20200117"
+    pedestal_ids_dir.mkdir(parents=True, exist_ok=True)
+    file = pedestal_ids_dir / "pedestal_ids_Run01808.0000.h5"
+    file.touch()
+    return file
+
+
+@pytest.fixture(scope="session")
 def sequence_list(
         running_analysis_dir,
         run_summary,
         drs4_time_calibration_files,
         systematic_correction_files,
         r0_data,
+        pedestal_ids_file,
 ):
     """Creates a sequence list from a run summary file."""
     options.directory = running_analysis_dir
@@ -247,6 +258,8 @@ def sequence_list(
 
     for file in r0_data:
         assert file.exists()
+
+    assert pedestal_ids_file.exists()
 
     subrun_list = extractsubruns(run_summary)
     run_list = extractruns(subrun_list)

--- a/osa/job.py
+++ b/osa/job.py
@@ -560,8 +560,7 @@ def data_sequence_job_template(sequence):
         content += set_cache_dirs()
         content += "\n"
         # Use the SLURM env variables
-        content += "subruns = os.getenv('SLURM_ARRAY_TASK_ID')\n"
-        content += "job_id = os.getenv('SLURM_JOB_ID')\n"
+        content += "subruns = int(os.getenv('SLURM_ARRAY_TASK_ID'))\n"
     else:
         # Just process the first subrun without SLURM
         content += "subruns = 0\n"
@@ -636,7 +635,6 @@ def calibration_sequence_job_template(sequence):
         content += "\n"
         # Use the SLURM env variables
         content += "subruns = os.getenv('SLURM_ARRAY_TASK_ID')\n"
-        content += "job_id = os.getenv('SLURM_JOB_ID')\n"
     else:
         # Just process the first subrun without SLURM
         content += "subruns = 0\n"

--- a/osa/provenance/utils.py
+++ b/osa/provenance/utils.py
@@ -92,15 +92,16 @@ def parse_variables(class_instance):
         )
 
     if class_instance.__name__ == "r0_to_dl1":
-        # calibrationfile   [0] .../20200218/pro/calibration_filters_52.Run02006.0000.h5
-        # pedestalfile      [1] .../20200218/pro/drs4_pedestal.Run02005.0000.h5
-        # timecalibfile     [2] .../20191124/pro/time_calibration.Run01625.0000.h5
-        # systematic_corr   [3] .../20200101/pro/no_sys_corrected_calibration_scan_fit_20210514.0000.h5
-        # drivefile         [4] .../DrivePositioning/drive_log_20_02_18.txt
-        # runsummaryfile    [5] .../RunSummary/RunSummary_20200101.ecsv
-        # run_str           [6] 02006.0000
+        # calibration_file   [0] .../20200218/pro/calibration_filters_52.Run02006.0000.h5
+        # drs4_pedestal_file [1] .../20200218/pro/drs4_pedestal.Run02005.0000.h5
+        # time_calib_file    [2] .../20191124/pro/time_calibration.Run01625.0000.h5
+        # systematic_corr    [3] .../20200101/pro/no_sys_corrected_calibration_scan_fit_20210514.0000.h5
+        # drive_file         [4] .../DrivePositioning/drive_log_20_02_18.txt
+        # run_summary_file   [5] .../RunSummary/RunSummary_20200101.ecsv
+        # pedestal_ids_file  [6] .../RunSummary/RunSummary_20200101.ecsv
+        # run_str            [7] 02006.0000
 
-        run_subrun_id = class_instance.args[6]
+        run_subrun_id = class_instance.args[7]
         class_instance.ObservationRun = run_subrun_id.split(".")[0]
         # use realpath to resolve symbolic links and return abspath
         calibration_file = os.path.realpath(class_instance.args[0])

--- a/osa/scripts/closer.py
+++ b/osa/scripts/closer.py
@@ -399,7 +399,7 @@ def merge_files(sequence_list, data_level="DL2"):
                 "lstchain_merge_hdf5_files",
                 f"--input-dir={data_dir}",
                 f"--output-file={merged_file}",
-                "--no-image=True",
+                "--no-image",
                 "--no-progress",
                 f"--run-number={sequence.run}",
                 f"--pattern={pattern}",

--- a/osa/scripts/datasequence.py
+++ b/osa/scripts/datasequence.py
@@ -24,6 +24,7 @@ def data_sequence(
         systematic_correction_file: Path,
         drive_file: Path,
         run_summary: Path,
+        pedestal_ids_file: Path,
         run_str: str
 ):
     """
@@ -37,6 +38,7 @@ def data_sequence(
     systematic_correction_file: pathlib.Path
     drive_file: pathlib.Path
     run_summary: pathlib.Path
+    pedestal_ids_file: pathlib.Path
     run_str: str
 
     Returns
@@ -57,6 +59,7 @@ def data_sequence(
             systematic_correction_file,
             drive_file,
             run_summary,
+            pedestal_ids_file,
             run_str,
             history_file,
         )
@@ -105,6 +108,7 @@ def r0_to_dl1(
         systematic_correction_file: Path,
         drive_file: Path,
         run_summary: Path,
+        pedestal_ids_file: Path,
         run_str: str,
         history_file: Path,
 ):
@@ -122,6 +126,8 @@ def r0_to_dl1(
     drive_file: pathlib.Path
     run_summary: : pathlib.Path
         Path to the run summary file
+    pedestal_ids_file: pathlib.Path
+        Path to file containing the interleaved pedestal event ids
     run_str: str
         XXXXX.XXXX (run_number.subrun_number)
     history_file: pathlib.Path
@@ -147,6 +153,9 @@ def r0_to_dl1(
         f"--pointing-file={drive_file}",
         f"--run-summary-path={run_summary}",
     ]
+
+    if pedestal_ids_file is not None:
+        cmd.append(f"--pedestal-ids-path={pedestal_ids_file}")
 
     if options.simulate:
         return 0
@@ -313,6 +322,7 @@ def main():
         systematic_correction_file,
         drive_log_file,
         run_summary_file,
+        pedestal_ids_file,
         run_number,
     ) = data_sequence_cli_parsing()
 
@@ -329,6 +339,7 @@ def main():
         systematic_correction_file,
         drive_log_file,
         run_summary_file,
+        pedestal_ids_file,
         run_number,
     )
     sys.exit(rc)

--- a/osa/scripts/simulate_processing.py
+++ b/osa/scripts/simulate_processing.py
@@ -121,11 +121,10 @@ def parse_template(template, idx):
     keep = False
     for line in template.splitlines():
         if keep:
+            line = line.replace("f'", "")
             line = line.replace("'", "")
             line = line.replace(",", "")
-            line = line.replace(r"{0}.format(str(subruns).zfill(4))", str(idx).zfill(4))
-            if "--stdout=" in line or "--stderr" in line:
-                continue
+            line = line.replace(r"{subruns:04d}", str(idx).zfill(4))
             args.append(line.strip())
         if "subprocess.run" in line:
             keep = True

--- a/osa/scripts/simulate_processing.py
+++ b/osa/scripts/simulate_processing.py
@@ -14,7 +14,7 @@ import yaml
 
 from osa.configs import options
 from osa.configs.config import cfg
-from osa.job import create_job_template
+from osa.job import calibration_sequence_job_template, data_sequence_job_template
 from osa.nightsummary.extract import extractruns, extractsequences, extractsubruns
 from osa.nightsummary.nightsummary import run_summary_table
 from osa.provenance.utils import get_log_config
@@ -160,16 +160,12 @@ def simulate_processing():
         processed = False
         for sub_list in sequence.subrun_list:
             if sub_list.runobj.type == "PEDCALIB":
-                args_cal = parse_template(
-                    create_job_template(sequence, get_content=True), 0
-                )
+                args_cal = parse_template(calibration_sequence_job_template(sequence), 0)
                 simulate_calibration(args_cal)
             elif sub_list.runobj.type == "DATA":
                 with mp.Pool() as poolproc:
                     args_proc = [
-                        parse_template(
-                            create_job_template(sequence, get_content=True), subrun_idx
-                        )
+                        parse_template(data_sequence_job_template(sequence), subrun_idx)
                         for subrun_idx in range(sub_list.subrun)
                     ]
                     processed = poolproc.map(simulate_subrun_processing, args_proc)

--- a/osa/tests/test_jobs.py
+++ b/osa/tests/test_jobs.py
@@ -134,13 +134,13 @@ def test_create_job_template_scheduler(
         run_summary_file,
         pedestal_ids_file,
 ):
-    from osa.job import create_job_template
+    from osa.job import data_sequence_job_template
 
     assert pedestal_ids_file.exists()
 
     options.test = False
     options.simulate = False
-    content1 = create_job_template(sequence_list[1], get_content=True)
+    content1 = data_sequence_job_template(sequence_list[1])
     expected_content1 = dedent(f"""\
     #!/bin/env python
 
@@ -184,7 +184,7 @@ def test_create_job_template_scheduler(
 
     sys.exit(proc.returncode)""")
 
-    content2 = create_job_template(sequence_list[2], get_content=True)
+    content2 = data_sequence_job_template(sequence_list[2])
     expected_content2 = dedent(f"""\
         #!/bin/env python
 
@@ -245,7 +245,7 @@ def test_create_job_template_local(
         r0_data
 ):
     """Check the job file in local mode (assuming no scheduler)."""
-    from osa.job import create_job_template
+    from osa.job import data_sequence_job_template
 
     for file in drs4_time_calibration_files:
         assert file.exists()
@@ -261,7 +261,7 @@ def test_create_job_template_local(
     options.test = True
     options.simulate = False
 
-    content1 = create_job_template(sequence_list[1], get_content=True)
+    content1 = data_sequence_job_template(sequence_list[1])
     expected_content1 = dedent(f"""\
     #!/bin/env python
 
@@ -292,7 +292,7 @@ def test_create_job_template_local(
 
     sys.exit(proc.returncode)""")
 
-    content2 = create_job_template(sequence_list[2], get_content=True)
+    content2 = data_sequence_job_template(sequence_list[2])
     expected_content2 = dedent(f"""\
         #!/bin/env python
 
@@ -332,10 +332,10 @@ def test_create_job_template_local(
 
 def test_create_job_scheduler_calibration(sequence_list):
     """Check the pilot job file for the calibration pipeline."""
-    from osa.job import create_job_template
+    from osa.job import calibration_sequence_job_template
     options.test = True
     options.simulate = False
-    content = create_job_template(sequence_list[0], get_content=True)
+    content = calibration_sequence_job_template(sequence_list[0])
     expected_content = dedent(f"""\
     #!/bin/env python
 

--- a/osa/tests/test_jobs.py
+++ b/osa/tests/test_jobs.py
@@ -161,8 +161,7 @@ def test_create_job_template_scheduler(
     os.environ['CTAPIPE_CACHE'] = '/fefs/aswg/lstanalyzer/.ctapipe/ctapipe_cache'
     os.environ['CTAPIPE_SVC_PATH'] = '/fefs/aswg/lstanalyzer/.ctapipe/service'
     os.environ['MPLCONFIGDIR'] = '/fefs/aswg/lstanalyzer/.cache/matplotlib'
-    subruns = os.getenv('SLURM_ARRAY_TASK_ID')
-    job_id = os.getenv('SLURM_JOB_ID')
+    subruns = int(os.getenv('SLURM_ARRAY_TASK_ID'))
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         os.environ['NUMBA_CACHE_DIR'] = tmpdirname
@@ -205,8 +204,7 @@ def test_create_job_template_scheduler(
         os.environ['CTAPIPE_CACHE'] = '/fefs/aswg/lstanalyzer/.ctapipe/ctapipe_cache'
         os.environ['CTAPIPE_SVC_PATH'] = '/fefs/aswg/lstanalyzer/.ctapipe/service'
         os.environ['MPLCONFIGDIR'] = '/fefs/aswg/lstanalyzer/.cache/matplotlib'
-        subruns = os.getenv('SLURM_ARRAY_TASK_ID')
-        job_id = os.getenv('SLURM_JOB_ID')
+        subruns = int(os.getenv('SLURM_ARRAY_TASK_ID'))
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             os.environ['NUMBA_CACHE_DIR'] = tmpdirname

--- a/osa/utils/cliopts.py
+++ b/osa/utils/cliopts.py
@@ -357,6 +357,11 @@ def data_sequence_argparser():
         type=Path,
         help="Path of run summary file with time reference information",
     )
+    parser.add_argument(
+        "--pedestal-ids-file",
+        type=Path,
+        help="Path to a file containing the ids of the interleaved pedestal events",
+    )
     parser.add_argument("run_number", help="Number of the run to be processed")
     parser.add_argument("tel_id", choices=["ST", "LST1", "LST2"])
     return parser
@@ -406,6 +411,7 @@ def data_sequence_cli_parsing():
         opts.systematic_correction_file,
         opts.drive_file,
         opts.run_summary,
+        opts.pedestal_ids_file,
         opts.run_number,
     )
 


### PR DESCRIPTION
Closes #95

Check if pedestal ids files exist for a given run. If so, it is passed as argument to r0 to dl1 script