### PR TITLE
Allows setting how many days look back when fetching sacct job information

### DIFF
--- a/cfg/sequencer.cfg
+++ b/cfg/sequencer.cfg
@@ -70,6 +70,9 @@ PARTITION_PEDCALIB: short
 PARTITION_DATA: long
 MEMSIZE_PEDCALIB: 3GB
 MEMSIZE_DATA: 16GB
+# Days from current day up to which the jobs are fetched from the queue.
+# Default is None (left empty).
+STARTTIME_DAYS_SACCT:
 
 [WEBSERVER]
 # Set the server address and port to transfer the datacheck plots

--- a/osa/job.py
+++ b/osa/job.py
@@ -779,18 +779,20 @@ def run_sacct() -> StringIO:
         log.warning("No job info available since sacct command is not available")
         return StringIO()
 
-    start_date = (datetime.date.today() - datetime.timedelta(weeks=1)).isoformat()
     sacct_cmd = [
         "sacct",
         "-n",
         "--parsable2",
         "--delimiter=,",
         "--units=G",
-        "--starttime",
-        start_date,
         "-o",
         ",".join(FORMAT_SLURM),
     ]
+    if cfg.get("SLURM", "STARTTIME_DAYS_SACCT"):
+        days = int(cfg.get("SLURM", "STARTTIME_DAYS_SACCT"))
+        start_date = (datetime.date.today() - datetime.timedelta(days=days)).isoformat()
+        sacct_cmd.extend(["--starttime", start_date])
+
     return StringIO(sp.check_output(sacct_cmd).decode())
 
 


### PR DESCRIPTION
By default, osa would only look back within the same day for job information (param `STARTTIME_DAYS_SACCT` left empty). Otherwise set how many days osa is to look back in the slurm database