### PR TITLE
Refactor extract sequences, improve logging and cleanup

### DIFF
--- a/osa/configs/datamodel.py
+++ b/osa/configs/datamodel.py
@@ -107,34 +107,3 @@ class SequenceData(Sequence):
         self.datacheckstatus = None
         self.dl2status = None
         self.dl3status = None
-
-
-class SequenceStereo(Sequence):
-    def __init__(self, v, w):
-        super(SequenceStereo, self).__init__()
-        attr_list = [
-            "run",
-            "subrun_list",
-            "subruns",
-            "wobble",
-            "sourcewobble",
-            "source",
-            "night",
-        ]
-        for a in attr_list:
-            # this copies the unique attrs of both sequences
-            self.__dict__.update({a: self.set_unique(v.__dict__[a], w.__dict__[a])})
-        self.type = "STEREO"
-        self.telescope = "ST"
-        self.subruns = v.subruns + w.subruns
-        self.parent_list = [v, w]
-        self.parent = f"{v.seq},{w.seq}"
-        self.parentjobid = f"{v.jobid}:{w.jobid}"
-        self.superstarstatus = None
-
-    @staticmethod
-    def set_unique(v_attr, w_attr):
-        if v_attr == w_attr:
-            return v_attr
-
-        return None

--- a/osa/scripts/calibration_pipeline.py
+++ b/osa/scripts/calibration_pipeline.py
@@ -29,7 +29,7 @@ __all__ = [
     "calibration_file_command",
 ]
 
-log = myLogger(logging.getLogger(__name__))
+log = myLogger(logging.getLogger())
 
 
 def is_calibration_produced(drs4_pedestal_run_id: str, pedcal_run_id: str) -> bool:

--- a/osa/scripts/calibration_pipeline.py
+++ b/osa/scripts/calibration_pipeline.py
@@ -18,7 +18,6 @@ from osa.job import historylevel
 from osa.job import run_program_with_history_logging
 from osa.provenance.capture import trace
 from osa.utils.cliopts import calibration_pipeline_cliparsing
-from osa.utils.logging import myLogger
 from osa.utils.utils import lstdate_to_dir
 
 __all__ = [
@@ -29,7 +28,7 @@ __all__ = [
     "calibration_file_command",
 ]
 
-log = myLogger(logging.getLogger())
+log = logging.getLogger()
 
 
 def is_calibration_produced(drs4_pedestal_run_id: str, pedcal_run_id: str) -> bool:

--- a/osa/scripts/datasequence.py
+++ b/osa/scripts/datasequence.py
@@ -46,8 +46,9 @@ def data_sequence(
     rc: int
         Return code of the last executed command.
     """
-    history_file = Path(options.directory) / \
-        f"sequence_{options.tel_id}_{run_str}.history"
+    history_file = (
+        Path(options.directory) / f"sequence_{options.tel_id}_{run_str}.history"
+    )
     level, rc = (4, 0) if options.simulate else historylevel(history_file, "DATA")
     log.info(f"Going to level {level}")
 
@@ -73,8 +74,7 @@ def data_sequence(
             log.info(f"Going to level {level}")
         else:
             level -= 2
-            log.info(f"No images stored in dl1ab. "
-                     f"Producing DL2. Going to level {level}")
+            log.info(f"No images stored in dl1ab. Producing DL2. Going to level {level}")
 
     if level == 2:
         rc = dl1_datacheck(run_str, history_file)

--- a/osa/scripts/datasequence.py
+++ b/osa/scripts/datasequence.py
@@ -9,12 +9,11 @@ from osa.configs.config import cfg
 from osa.job import historylevel, run_program_with_history_logging
 from osa.provenance.capture import trace
 from osa.utils.cliopts import data_sequence_cli_parsing
-from osa.utils.logging import myLogger
 from osa.utils.utils import lstdate_to_dir
 
 __all__ = ["data_sequence", "r0_to_dl1", "dl1_to_dl2", "dl1ab", "dl1_datacheck"]
 
-log = myLogger(logging.getLogger())
+log = logging.getLogger()
 
 
 def data_sequence(

--- a/osa/scripts/sequencer.py
+++ b/osa/scripts/sequencer.py
@@ -25,8 +25,8 @@ from osa.job import (
 from osa.nightsummary.extract import (
     extractruns,
     extractsequences,
-    extractsequencesstereo,
     extractsubruns,
+    sort_run_list
 )
 from osa.nightsummary.nightsummary import run_summary_table
 from osa.report import start
@@ -37,7 +37,6 @@ from osa.veto import get_closed_list, get_veto_list
 
 __all__ = [
     "single_process",
-    "stereo_process",
     "update_sequence_status",
     "get_status_for_sequence",
     "output_matrix",
@@ -104,7 +103,8 @@ def single_process(telescope):
     subrun_list = extractsubruns(summary_table)
     run_list = extractruns(subrun_list)
     # modifies run_list by adding the seq and parent info into runs
-    sequence_list = extractsequences(run_list)
+    sorted_run_list = sort_run_list(run_list)
+    sequence_list = extractsequences(sorted_run_list)
 
     # Workflow and submission
     # if not options.simulate:
@@ -129,46 +129,6 @@ def single_process(telescope):
         # updatesequencedb(sequence_list)
         report_sequences(sequence_list)
 
-    return sequence_list
-
-
-def stereo_process(telescope, s1_list, s2_list):
-    """
-    Runs the stereo process for two or more telescopes
-    Currently not implemented.
-
-    Parameters
-    ----------
-    telescope
-    s1_list
-    s2_list
-
-    Returns
-    -------
-    sequence_list : list
-    """
-    options.tel_id = telescope
-    options.directory = set_default_directory_if_needed()
-
-    # building the sequences
-    sequence_list = extractsequencesstereo(s1_list, s2_list)
-    # Workflow and Submission
-    # write_workflow(sequence_list)
-
-    # Adds the scripts
-    prepare_jobs(sequence_list)
-
-    # Update sequences objects with information from SLURM
-    update_job_info(sequence_list)
-
-    get_veto_list(sequence_list)
-    get_closed_list(sequence_list)
-    update_sequence_status(sequence_list)
-    submit_jobs(sequence_list)
-    # finalizing report
-    report_sequences(sequence_list)
-    # cleaning
-    options.directory = None
     return sequence_list
 
 


### PR DESCRIPTION
Stop relying on source name to build sequence list since DRS4 and PEDCALIB sequences do not have source names.