### PR TITLE
Remove pyparsing requirement from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "lstchain==0.9.2",
         "ctapipe~=0.12.0",
         "matplotlib~=3.5",
-        "pyparsing~=2.4",
         "numpy<1.22.0a0",
         "pandas",
         "pyyaml",


### PR DESCRIPTION
Remove fixed version of pyparsing from setup since is not a direct dependency of osa. Pyparsing is still in the environment yml file