### PR TITLE
Problem reading the config file

### DIFF
--- a/osa/configs/config.py
+++ b/osa/configs/config.py
@@ -31,6 +31,7 @@ def read_config():
     for idx, arg in enumerate(sys.argv):
         if arg in ["-c", "--config"]:
             options.configfile = sys.argv[idx + 1]
+            break
         else:
             options.configfile = DEFAULT_CFG
 

--- a/osa/utils/cliopts.py
+++ b/osa/utils/cliopts.py
@@ -396,8 +396,8 @@ def simproc_argparser():
     parser.add_argument(
         "-c",
         "--config",
-        default="configs/sequencer.cfg",
-        help="use specific config file [default configs/sequencer.cfg]",
+        default=DEFAULT_CFG,
+        help="use specific config file",
     )
     parser.add_argument(
         "-p", action="store_true", dest="provenance", help="produce provenance files"


### PR DESCRIPTION
If the config file is not the last argument, the read_config function is always taking as config file the DEFAULT_CFG. I add a "break" so that if a config file is passed as an argument it stops looping over other arguments that would overwrite the provided config file with the DEFAULT_CFG.