### PR TITLE
Remove SubrunObj from data model

### DIFF
--- a/osa/configs/datamodel.py
+++ b/osa/configs/datamodel.py
@@ -1,60 +1,17 @@
-class Period(object):
-    def __init__(self):
-        self.period = None
+from dataclasses import dataclass
 
 
-class Night(Period):
-    def __init__(self):
-        super(Night, self).__init__()
-        self.night = None
-
-
-class Telescope(Night):
-    def __init__(self):
-        super(Telescope, self).__init__()
-        self.telescope = None
-
-
-class Source(Telescope):
-    def __init__(self):
-        super(Source, self).__init__()
-        self.source_name = None
-        self.source_ra = None
-        self.source_dec = None
-
-
-class Wobble(Source):
-    def __init__(self):
-        super(Wobble, self).__init__()
-        self.sourcewobble = None
-        self.wobble = None
-
-
-class RunObj(Wobble):
-    def __init__(self):
-        super(RunObj, self).__init__()
-        self.run_str = None
-        self.run = None
-        self.type = None
-        self.subrun_list = []
-        self.subruns = None
-
-
-class SubrunObj(RunObj):
-    def __init__(self):
-        super(SubrunObj, self).__init__()
-        self.runobj = None
-        self.subrun = None
-        self.kind = None
-        self.timestamp = None
-        self.time = None
-        self.date = None
-        self.ucts_timestamp = None
-        self.dragon_reference_time = None
-        self.dragon_reference_module_id = None
-        self.dragon_reference_module_index = None
-        self.dragon_reference_counter = None
-        self.dragon_reference_source = None
+@dataclass
+class RunObj:
+    run_str: str = None
+    run: int = None
+    type: str = None
+    subruns: int = None
+    source_name: str = None
+    source_ra: float = None
+    source_dec: float = None
+    telescope: str = "LST1"
+    night: str = None
 
 
 class Sequence(RunObj):

--- a/osa/configs/datamodel.py
+++ b/osa/configs/datamodel.py
@@ -1,3 +1,5 @@
+"""Definition of classes containing run and sequence information"""
+
 from dataclasses import dataclass
 
 

--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -21,7 +21,7 @@ import pytest
 
 from osa.configs import options
 from osa.configs.config import cfg
-from osa.nightsummary.extract import extractruns, extractsubruns, extract_sequences
+from osa.nightsummary.extract import extract_runs, extract_sequences
 from osa.nightsummary.nightsummary import run_summary_table
 from osa.scripts.tests.test_osa_scripts import run_program
 from osa.utils.utils import date_to_dir
@@ -335,8 +335,7 @@ def sequence_list(
     assert pedestal_ids_file.exists()
     assert merged_run_summary.exists()
 
-    subrun_list = extractsubruns(run_summary)
-    run_list = extractruns(subrun_list)
+    run_list = extract_runs(run_summary)
     options.test = False
     return extract_sequences(options.date, run_list)
 

--- a/osa/job.py
+++ b/osa/job.py
@@ -335,8 +335,8 @@ def scheduler_env_variables(sequence, scheduler="slurm"):
         f"--error=log/Run{sequence.run:05d}.%4a_jobid_%A.err",
     ]
 
-    # Get the number of subruns. The number of subruns starts counting from 0.
-    subruns = int(sequence.subrun_list[-1].subrun) - 1
+    # Get the number of subruns counting from 0.
+    subruns = sequence.subruns - 1
 
     # Depending on the type of sequence, we need to set
     # different sbatch environment variables

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -141,29 +141,6 @@ def extract_runs(summary_table):
     return run_list
 
 
-# def extractruns(subrun_list):
-#     """
-#
-#     Parameters
-#     ----------
-#     subrun_list
-#         List of subruns
-#
-#     Returns
-#     -------
-#     run_list
-#
-#     """
-#     run_list = []
-#     for subrun in subrun_list:
-#         if subrun.runobj not in run_list:
-#             subrun.runobj.subruns = subrun.subrun
-#             run_list.append(subrun.runobj)
-#
-#     log.debug("Run list extracted")
-#     return run_list
-
-
 def extract_sequences(date: datetime, run_obj_list: List[RunObj]) -> List[Sequence]:
     """
     Create calibration and data sequences from run objects.
@@ -237,7 +214,6 @@ def extract_sequences(date: datetime, run_obj_list: List[RunObj]) -> List[Sequen
 def build_sequences(date: datetime) -> List:
     """Build the list of sequences to process from a given date."""
     summary_table = run_summary_table(date)
-    # subrun_list = extractsubruns(summary_table)
     run_list = extract_runs(summary_table)
     # modifies run_list by adding the seq and parent info into runs
     return extract_sequences(date, run_list)

--- a/osa/scripts/closer.py
+++ b/osa/scripts/closer.py
@@ -16,7 +16,7 @@ from osa import osadb
 from osa.configs import options
 from osa.configs.config import cfg
 from osa.job import are_all_jobs_correctly_finished, save_job_information
-from osa.nightsummary.extract import extractruns, extract_sequences, extractsubruns
+from osa.nightsummary.extract import extract_runs, extract_sequences
 from osa.nightsummary.nightsummary import run_summary_table
 from osa.paths import destination_dir
 from osa.raw import is_raw_data_available
@@ -269,8 +269,7 @@ def is_finished_check(run_summary):
     sequence_success = False
     if run_summary is not None:
         # building the sequences (the same way as the sequencer)
-        subrun_list = extractsubruns(run_summary)
-        run_list = extractruns(subrun_list)
+        run_list = extract_runs(run_summary)
         sequence_list = extract_sequences(options.date, run_list)
 
         if are_all_jobs_correctly_finished(sequence_list):

--- a/osa/scripts/simulate_processing.py
+++ b/osa/scripts/simulate_processing.py
@@ -151,17 +151,16 @@ def simulate_processing():
     # simulate data calibration and reduction
     for sequence in sequence_list:
         processed = False
-        for sub_list in sequence.subrun_list:
-            if sub_list.runobj.type == "PEDCALIB":
-                args_cal = parse_template(calibration_sequence_job_template(sequence), 0)
-                simulate_calibration(args_cal)
-            elif sub_list.runobj.type == "DATA":
-                with mp.Pool() as poolproc:
-                    args_proc = [
-                        parse_template(data_sequence_job_template(sequence), subrun_idx)
-                        for subrun_idx in range(sub_list.subrun)
-                    ]
-                    processed = poolproc.map(simulate_subrun_processing, args_proc)
+        if sequence.type == "PEDCALIB":
+            args_cal = parse_template(calibration_sequence_job_template(sequence), 0)
+            simulate_calibration(args_cal)
+        elif sequence.type == "DATA":
+            with mp.Pool() as poolproc:
+                args_proc = [
+                    parse_template(data_sequence_job_template(sequence), subrun_idx)
+                    for subrun_idx in range(sequence.subruns)
+                ]
+                processed = poolproc.map(simulate_subrun_processing, args_proc)
         # produce prov if overwrite prov arg
         if processed and options.provenance:
             command = "provprocess"


### PR DESCRIPTION
Having a subrun object is overkill as the workflow generation happens at the run level. The extraction of sequences and their usage have been adapted as well. Replaces #126, which had additional changes and was more challenging to review