### PR TITLE
Require python 3.8 and above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -36,10 +36,6 @@ jobs:
       run:
         shell: bash -l {0}
 
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8]
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
+          PYTHON_VERSION: 3.8
 
         run: |
           python --version

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ making use of the `cta-lstchain`_ analysis library.
 * Code: https://github.com/cta-observatory/lstosa
 * Docs: https://lstosa.readthedocs.io/
 * License: BSD-3
-* Python 3.7, 3.8
+* Python 3.8+
 * Authors: Daniel Morcuende, Lab Saha, José Enrique Ruiz, José Luis Contreras, Andrés Baquero, María Lainez
 
 .. _`cta-lstchain`: https://github.com/cta-observatory/cta-lstchain

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 packages = find:
 setup_requires = setuptools_scm
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     astropy~=4.2
     lstchain==0.9.6


### PR DESCRIPTION
Because there is some new syntax working as of python 3.8 