### PR TITLE
add possibility to analyze data for nights without DRS4 or PEDCALIB runs

### DIFF
--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -242,6 +242,74 @@ def run_summary_file(run_summary_dir):
 
 
 @pytest.fixture(scope="session")
+def run_summary_file_no_calib(run_summary_dir):
+
+    summary_content = dedent(
+        """\# %ECSV 1.0
+            # ---
+            # datatype:
+            # - {name: run_id, datatype: int64}
+            # - {name: n_subruns, datatype: int64}
+            # - {name: run_type, datatype: string}
+            # - {name: ucts_timestamp, datatype: int64}
+            # - {name: run_start, datatype: int64}
+            # - {name: dragon_reference_time, datatype: int64}
+            # - {name: dragon_reference_module_id, datatype: int16}
+            # - {name: dragon_reference_module_index, datatype: int16}
+            # - {name: dragon_reference_counter, datatype: uint64}
+            # - {name: dragon_reference_source, datatype: string}
+            # delimiter: ','
+            # meta: !!omap
+            # - {date: '2022-09-23'}
+            # - {lstchain_version: 0.9.6}
+            # schema: astropy-2.0
+            run_id,n_subruns,run_type,ucts_timestamp,run_start,dragon_reference_time,dragon_reference_module_id,dragon_reference_module_index,dragon_reference_counter,dragon_reference_source
+            9379,21,DATA,-1,1663951379000000000,1663951379000000000,0,0,6463544800,run_start
+            9380,44,DRS4,1663951929600198168,1663951917000000000,1663951929600198168,0,0,5600197900,ucts
+            9381,41,DRS4,1663952467501824402,1663952457000000000,1663952467501824402,0,0,3501824100,ucts"""
+            )
+
+    summary_file = run_summary_dir / "RunSummary_20220923.ecsv"
+    summary_file.touch()
+    summary_file.write_text(summary_content)
+    return summary_file
+
+
+@pytest.fixture(scope="session")
+def run_summary_file_no_calib2(run_summary_dir):
+
+    summary_content = dedent(
+        """\# %ECSV 1.0
+            # ---
+            # datatype:
+            # - {name: run_id, datatype: int64}
+            # - {name: n_subruns, datatype: int64}
+            # - {name: run_type, datatype: string}
+            # - {name: ucts_timestamp, datatype: int64}
+            # - {name: run_start, datatype: int64}
+            # - {name: dragon_reference_time, datatype: int64}
+            # - {name: dragon_reference_module_id, datatype: int16}
+            # - {name: dragon_reference_module_index, datatype: int16}
+            # - {name: dragon_reference_counter, datatype: uint64}
+            # - {name: dragon_reference_source, datatype: string}
+            # delimiter: ','
+            # meta: !!omap
+            # - {date: '2022-09-22'}
+            # - {lstchain_version: 0.9.6}
+            # schema: astropy-2.0
+            run_id,n_subruns,run_type,ucts_timestamp,run_start,dragon_reference_time,dragon_reference_module_id,dragon_reference_module_index,dragon_reference_counter,dragon_reference_source
+            9326,4,DRS4,1663877740307617642,1663877725000000000,1663877740307617642,0,0,6307617400,ucts
+            9327,3,ERRPEDCALIB,1663878027873304499,1663878015000000000,1663878027873304499,0,0,3873304200,ucts
+            9258,5,PEDCALIB,1663796417227478675,1663796405000000000,1663796417227478675,90,0,5227478400,ucts"""
+            )
+
+    summary_file = run_summary_dir / "RunSummary_20220922.ecsv"
+    summary_file.touch()
+    summary_file.write_text(summary_content)
+    return summary_file
+
+
+@pytest.fixture(scope="session")
 def merged_run_summary(base_test_dir):
     """Mock merged run summary file for testing."""
     summary_content = dedent(

--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -245,29 +245,30 @@ def run_summary_file(run_summary_dir):
 def run_summary_file_no_calib(run_summary_dir):
 
     summary_content = dedent(
-        """\# %ECSV 1.0
-            # ---
-            # datatype:
-            # - {name: run_id, datatype: int64}
-            # - {name: n_subruns, datatype: int64}
-            # - {name: run_type, datatype: string}
-            # - {name: ucts_timestamp, datatype: int64}
-            # - {name: run_start, datatype: int64}
-            # - {name: dragon_reference_time, datatype: int64}
-            # - {name: dragon_reference_module_id, datatype: int16}
-            # - {name: dragon_reference_module_index, datatype: int16}
-            # - {name: dragon_reference_counter, datatype: uint64}
-            # - {name: dragon_reference_source, datatype: string}
-            # delimiter: ','
-            # meta: !!omap
-            # - {date: '2022-09-23'}
-            # - {lstchain_version: 0.9.6}
-            # schema: astropy-2.0
-            run_id,n_subruns,run_type,ucts_timestamp,run_start,dragon_reference_time,dragon_reference_module_id,dragon_reference_module_index,dragon_reference_counter,dragon_reference_source
-            9379,21,DATA,-1,1663951379000000000,1663951379000000000,0,0,6463544800,run_start
-            9380,44,DRS4,1663951929600198168,1663951917000000000,1663951929600198168,0,0,5600197900,ucts
-            9381,41,DRS4,1663952467501824402,1663952457000000000,1663952467501824402,0,0,3501824100,ucts"""
-            )
+        """\
+    # %ECSV 1.0
+    # ---
+    # datatype:
+    # - {name: run_id, datatype: int64}
+    # - {name: n_subruns, datatype: int64}
+    # - {name: run_type, datatype: string}
+    # - {name: ucts_timestamp, datatype: int64}
+    # - {name: run_start, datatype: int64}
+    # - {name: dragon_reference_time, datatype: int64}
+    # - {name: dragon_reference_module_id, datatype: int16}
+    # - {name: dragon_reference_module_index, datatype: int16}
+    # - {name: dragon_reference_counter, datatype: uint64}
+    # - {name: dragon_reference_source, datatype: string}
+    # delimiter: ','
+    # meta: !!omap
+    # - {date: '2022-09-23'}
+    # - {lstchain_version: 0.9.6}
+    # schema: astropy-2.0
+    run_id,n_subruns,run_type,ucts_timestamp,run_start,dragon_reference_time,dragon_reference_module_id,dragon_reference_module_index,dragon_reference_counter,dragon_reference_source
+    9379,21,DATA,-1,1663951379000000000,1663951379000000000,0,0,6463544800,run_start
+    9380,44,DRS4,1663951929600198168,1663951917000000000,1663951929600198168,0,0,5600197900,ucts
+    9381,41,DRS4,1663952467501824402,1663952457000000000,1663952467501824402,0,0,3501824100,ucts"""
+    )
 
     summary_file = run_summary_dir / "RunSummary_20220923.ecsv"
     summary_file.touch()
@@ -279,29 +280,30 @@ def run_summary_file_no_calib(run_summary_dir):
 def run_summary_file_no_calib2(run_summary_dir):
 
     summary_content = dedent(
-        """\# %ECSV 1.0
-            # ---
-            # datatype:
-            # - {name: run_id, datatype: int64}
-            # - {name: n_subruns, datatype: int64}
-            # - {name: run_type, datatype: string}
-            # - {name: ucts_timestamp, datatype: int64}
-            # - {name: run_start, datatype: int64}
-            # - {name: dragon_reference_time, datatype: int64}
-            # - {name: dragon_reference_module_id, datatype: int16}
-            # - {name: dragon_reference_module_index, datatype: int16}
-            # - {name: dragon_reference_counter, datatype: uint64}
-            # - {name: dragon_reference_source, datatype: string}
-            # delimiter: ','
-            # meta: !!omap
-            # - {date: '2022-09-22'}
-            # - {lstchain_version: 0.9.6}
-            # schema: astropy-2.0
-            run_id,n_subruns,run_type,ucts_timestamp,run_start,dragon_reference_time,dragon_reference_module_id,dragon_reference_module_index,dragon_reference_counter,dragon_reference_source
-            9326,4,DRS4,1663877740307617642,1663877725000000000,1663877740307617642,0,0,6307617400,ucts
-            9327,3,ERRPEDCALIB,1663878027873304499,1663878015000000000,1663878027873304499,0,0,3873304200,ucts
-            9258,5,PEDCALIB,1663796417227478675,1663796405000000000,1663796417227478675,90,0,5227478400,ucts"""
-            )
+        """\
+    # %ECSV 1.0
+    # ---
+    # datatype:
+    # - {name: run_id, datatype: int64}
+    # - {name: n_subruns, datatype: int64}
+    # - {name: run_type, datatype: string}
+    # - {name: ucts_timestamp, datatype: int64}
+    # - {name: run_start, datatype: int64}
+    # - {name: dragon_reference_time, datatype: int64}
+    # - {name: dragon_reference_module_id, datatype: int16}
+    # - {name: dragon_reference_module_index, datatype: int16}
+    # - {name: dragon_reference_counter, datatype: uint64}
+    # - {name: dragon_reference_source, datatype: string}
+    # delimiter: ','
+    # meta: !!omap
+    # - {date: '2022-09-22'}
+    # - {lstchain_version: 0.9.6}
+    # schema: astropy-2.0
+    run_id,n_subruns,run_type,ucts_timestamp,run_start,dragon_reference_time,dragon_reference_module_id,dragon_reference_module_index,dragon_reference_counter,dragon_reference_source
+    9326,4,DRS4,1663877740307617642,1663877725000000000,1663877740307617642,0,0,6307617400,ucts
+    9327,3,ERRPEDCALIB,1663878027873304499,1663878015000000000,1663878027873304499,0,0,3873304200,ucts
+    9258,5,PEDCALIB,1663796417227478675,1663796405000000000,1663796417227478675,90,0,5227478400,ucts"""
+    )
 
     summary_file = run_summary_dir / "RunSummary_20220922.ecsv"
     summary_file.touch()

--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -313,7 +313,7 @@ def run_summary_file_no_calib2(run_summary_dir):
 
 @pytest.fixture(scope="session")
 def merged_run_summary(base_test_dir):
-"""Mock merged run summary file for testing."""
+    """Mock merged run summary file for testing."""
     summary_content = dedent(
         """\
     # %ECSV 1.0

--- a/osa/conftest.py
+++ b/osa/conftest.py
@@ -313,7 +313,7 @@ def run_summary_file_no_calib2(run_summary_dir):
 
 @pytest.fixture(scope="session")
 def merged_run_summary(base_test_dir):
-    """Mock merged run summary file for testing."""
+"""Mock merged run summary file for testing."""
     summary_content = dedent(
         """\
     # %ECSV 1.0
@@ -349,7 +349,13 @@ def merged_run_summary(base_test_dir):
     2020-01-17 1806 PEDCALIB 35 2020-01-18T00:44:06.000 8.6 29.1 45.5 6.9
     2020-01-17 1807 DATA 35 2020-01-18T00:44:06.000 6.6 2.8 70.4 10.1
     2020-01-17 1808 DATA 35 2020-01-18T00:44:06.000 8.6 9.2 60.8 3.2
-    2020-01-17 1809 PEDCALIB 4 2020-01-18T00:44:06.000 6.9 4.2 16.8 11.2"""
+    2020-01-17 1809 PEDCALIB 4 2020-01-18T00:44:06.000 6.9 4.2 16.8 11.2
+    2022-09-22 9326 DRS4 4 2021-09-22T00:44:06.000 6.9 4.2 16.8 11.2
+    2022-09-22 9327 ERRPEDCALIB 3 2021-09-22T00:44:06.000 6.9 4.2 16.8 11.2
+    2022-09-22 9258 PEDCALIB 5 2021-09-22T00:44:06.000 6.9 4.2 16.8 11.2
+    2022-09-23 9379 DATA 21 2021-09-23T00:44:06.000 6.9 4.2 16.8 11.2
+    2022-09-23 9380 DRS4 44 2021-09-23T00:44:06.000 6.9 4.2 16.8 11.2
+    2022-09-23 9381 DRS4 41 2021-09-23T00:44:06.000 6.9 4.2 16.8 11.2"""
     )
 
     merged_summary_dir = base_test_dir / "OSA/Catalog"

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -46,18 +46,24 @@ def get_data_runs(date: datetime):
 def get_last_drs4(date: datetime) -> int:
     """Return run_id of the last DRS4 run for the given date to be used for data processing."""
     summary = run_summary_table(date)
-    while not (np.array(summary["run_type"] == "DRS4")).any():
+    n_max = 4
+    n = 1
+    while not (np.array(summary["run_type"] == "DRS4")).any() & n <= n_max:
         date = date - timedelta(days=1)
         summary = run_summary_table(date)
+        n += 1
     return summary[summary["run_type"] == "DRS4"]["run_id"].max()
 
 
 def get_last_pedcalib(date) -> int:
     """Return run_id of the last PEDCALIB run for the given date to be used for data processing."""
     summary = run_summary_table(date)
-    while not (np.array(summary["run_type"] == "PEDCALIB")).any():
+    n_max = 4
+    n = 1
+    while not (np.array(summary["run_type"] == "PEDCALIB")).any() & n <= n_max:
         date = date - timedelta(days=1)
         summary = run_summary_table(date)
+        n += 1
     return summary[summary["run_type"] == "PEDCALIB"]["run_id"].max()
 
 

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -48,11 +48,17 @@ def get_last_drs4(date: datetime) -> int:
     summary = run_summary_table(date)
     n_max = 4
     n = 1
-    while not (np.array(summary["run_type"] == "DRS4")).any() & n <= n_max:
+    while (np.array(summary["run_type"] == "DRS4")).any()==False & n <= n_max:
         date = date - timedelta(days=1)
         summary = run_summary_table(date)
         n += 1
-    return summary[summary["run_type"] == "DRS4"]["run_id"].max()
+
+    try:
+        return summary[summary["run_type"] == "DRS4"]["run_id"].max()
+
+    except ValueError:
+        log.warning("No DRS4 run found. Nothing to do. Exiting.")
+        sys.exit(0)
 
 
 def get_last_pedcalib(date) -> int:
@@ -60,11 +66,18 @@ def get_last_pedcalib(date) -> int:
     summary = run_summary_table(date)
     n_max = 4
     n = 1
-    while not (np.array(summary["run_type"] == "PEDCALIB")).any() & n <= n_max:
+    while (np.array(summary["run_type"] == "PEDCALIB")).any()==False & n <= n_max:
         date = date - timedelta(days=1)
+        print(date)
         summary = run_summary_table(date)
         n += 1
-    return summary[summary["run_type"] == "PEDCALIB"]["run_id"].max()
+    
+    try:
+        return summary[summary["run_type"] == "PEDCALIB"]["run_id"].max()
+    
+    except ValueError:
+        log.warning("No PEDCALIB run found. Nothing to do. Exiting.")
+        sys.exit(0)
 
 
 def extract_runs(summary_table):

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -82,6 +82,11 @@ def extract_runs(summary_table):
     -------
     subrun_list
     """
+    
+    if len(summary_table) == 0:
+        log.warning("No runs found for this date. Nothing to do. Exiting.")
+        sys.exit(0)
+
     run_list = []
 
     required_drs4_run = get_last_drs4(options.date)
@@ -175,10 +180,6 @@ def extract_runs(summary_table):
         run_table.write(source_catalog_file, overwrite=True, delimiter=",")
 
     log.debug("Subrun list extracted")
-
-    if not run_list:
-        log.warning("No runs found for this date. Nothing to do. Exiting.")
-        sys.exit(0)
 
     return run_list
 

--- a/osa/nightsummary/extract.py
+++ b/osa/nightsummary/extract.py
@@ -4,12 +4,12 @@
 import itertools
 import logging
 import sys
-import numpy as np
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List
 
+import numpy as np
 from astropy.table import Table
 
 from osa.configs import options
@@ -48,7 +48,7 @@ def get_last_drs4(date: datetime) -> int:
     summary = run_summary_table(date)
     n_max = 4
     n = 1
-    while (np.array(summary["run_type"] == "DRS4")).any()==False & n <= n_max:
+    while (np.array(summary["run_type"] == "DRS4")).any() == False & n <= n_max:
         date = date - timedelta(days=1)
         summary = run_summary_table(date)
         n += 1
@@ -66,15 +66,14 @@ def get_last_pedcalib(date) -> int:
     summary = run_summary_table(date)
     n_max = 4
     n = 1
-    while (np.array(summary["run_type"] == "PEDCALIB")).any()==False & n <= n_max:
+    while (np.array(summary["run_type"] == "PEDCALIB")).any() == False & n <= n_max:
         date = date - timedelta(days=1)
-        print(date)
         summary = run_summary_table(date)
         n += 1
-    
+
     try:
         return summary[summary["run_type"] == "PEDCALIB"]["run_id"].max()
-    
+
     except ValueError:
         log.warning("No PEDCALIB run found. Nothing to do. Exiting.")
         sys.exit(0)
@@ -95,7 +94,7 @@ def extract_runs(summary_table):
     -------
     subrun_list
     """
-    
+
     if len(summary_table) == 0:
         log.warning("No runs found for this date. Nothing to do. Exiting.")
         sys.exit(0)
@@ -117,7 +116,7 @@ def extract_runs(summary_table):
             subruns=run_info["n_subruns"],
         )
         run_list.append(run)
-        
+
     if required_pedcal_run not in summary_table["run_id"]:
         pedcal_date = get_run_date(required_pedcal_run)
         pedcal_date_summary = run_summary_table(pedcal_date)

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -30,18 +30,25 @@ def test_build_sequences(sequence_list):
         assert sequence.run == extracted_seq.run
 
 
-def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
+ddef test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
     """Test that for a day with no PEDCALIB run, the PEDCALIB
-     run of another previous day is taken as PEDCALIB run."""
+     run of another previous day is taken."""
     from osa.nightsummary.extract import extract_runs
     from osa.nightsummary.nightsummary import run_summary_table
+    from osa.configs import options
 
     assert run_summary_file_no_calib.exists()
     assert run_summary_file_no_calib2.exists()
 
     date = datetime.fromisoformat("2022-09-23")
+    options.date = date
     summary_table = run_summary_table(date)
     run_list = extract_runs(summary_table)
 
-    assert run_list[1].run == 9258
-    assert run_list[1].night == "2022-09-22"
+    for run in run_list:
+        if run.type == 'PEDCALIB':
+            pedcalib_run = run
+
+    assert pedcalib_run.run == 9258
+    assert pedcalib_run.night == "2022-09-20"
+

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -30,9 +30,14 @@ def test_build_sequences(sequence_list):
         assert sequence.run == extracted_seq.run
 
 
-def test_extract_runs():
+def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
+    """Test that for a day with no PEDCALIB run, the PEDCALIB
+     run of another previous day is taken as PEDCALIB run."""
     from osa.nightsummary.extract import extract_runs
-    from osa.nightsummary import run_summary_table
+    from osa.nightsummary.nightsummary import run_summary_table
+
+    assert run_summary_file_no_calib.exists()
+    assert run_summary_file_no_calib2.exists()
 
     date = datetime.fromisoformat("2022-09-23")
     summary_table = run_summary_table(date)

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-
 obs_date = datetime.fromisoformat("2020-01-17")
 
 
@@ -52,4 +51,4 @@ def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
     assert pedcalib_run.run == 9258
     assert pedcalib_run.night == "2022-09-20"
 
-options.date = datetime.fromisoformat("2020-01-17")
+    options.date = datetime.fromisoformat("2020-01-17")

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -52,3 +52,4 @@ def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
     assert pedcalib_run.run == 9258
     assert pedcalib_run.night == "2022-09-20"
 
+options.date = datetime.fromisoformat("2020-01-17")

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -28,3 +28,15 @@ def test_build_sequences(sequence_list):
     extracted_seq_list = build_sequences(date=obs_date)
     for sequence, extracted_seq in zip(sequence_list, extracted_seq_list):
         assert sequence.run == extracted_seq.run
+
+
+def test_extract_runs():
+    from osa.nightsummary.extract import extract_runs
+    from osa.nightsummary import run_summary_table
+
+    date = datetime.fromisoformat("2022-09-23")
+    summary_table = run_summary_table(date)
+    run_list = extract_runs(summary_table)
+
+    assert run_list[1].run == 9258
+    assert run_list[1].night == "2022-09-22"

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -29,7 +29,7 @@ def test_build_sequences(sequence_list):
         assert sequence.run == extracted_seq.run
 
 
-def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
+def test_no_calib_found(merged_run_summary, run_summary_file_no_calib, run_summary_file_no_calib2):
     """Test that for a day with no PEDCALIB run, the PEDCALIB
      run of another previous day is taken."""
     from osa.nightsummary.extract import extract_runs

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -38,6 +38,7 @@ def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
 
     assert run_summary_file_no_calib.exists()
     assert run_summary_file_no_calib2.exists()
+    assert merged_run_summary.exists()
 
     date = datetime.fromisoformat("2022-09-23")
     options.date = date
@@ -49,6 +50,6 @@ def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
             pedcalib_run = run
 
     assert pedcalib_run.run == 9258
-    assert pedcalib_run.night == "2022-09-20"
+    assert pedcalib_run.night == "2022-09-22"
 
     options.date = datetime.fromisoformat("2020-01-17")

--- a/osa/nightsummary/tests/test_extract.py
+++ b/osa/nightsummary/tests/test_extract.py
@@ -30,7 +30,7 @@ def test_build_sequences(sequence_list):
         assert sequence.run == extracted_seq.run
 
 
-ddef test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
+def test_no_calib_found(run_summary_file_no_calib, run_summary_file_no_calib2):
     """Test that for a day with no PEDCALIB run, the PEDCALIB
      run of another previous day is taken."""
     from osa.nightsummary.extract import extract_runs

--- a/osa/paths.py
+++ b/osa/paths.py
@@ -117,7 +117,7 @@ def get_calibration_file(run_id: int) -> Path:
     """
 
     calib_dir = Path(cfg.get("LST1", "CALIB_DIR"))
-    date = get_run_date(run_id)
+    date = utils.date_to_dir(get_run_date(run_id))
 
     if options.test:  # Run tests avoiding the access to the database
         filters = 52

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -340,7 +340,7 @@ def test_observation_finished():
 
 def test_no_runs_found():
     output = sp.run(
-        ["sequencer", "-s", "-d", "2020-05-05", "LST1"], text=True, stdout=sp.PIPE, stderr=sp.PIPE
+        ["sequencer", "-s", "-d", "2015-01-01", "LST1"], text=True, stdout=sp.PIPE, stderr=sp.PIPE
     )
     assert output.returncode == 0
     assert "No runs found for this date. Nothing to do. Exiting." in output.stderr.splitlines()[-1]

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -340,7 +340,7 @@ def test_observation_finished():
 
 def test_no_runs_found():
     output = sp.run(
-        ["sequencer", "-s", "-d", "2015-01-01", "LST1"], text=True, stdout=sp.PIPE, stderr=sp.PIPE
+        ["sequencer", "-s", "-d", "2020-01-25", "LST1"], text=True, stdout=sp.PIPE, stderr=sp.PIPE
     )
     assert output.returncode == 0
     assert "No runs found for this date. Nothing to do. Exiting." in output.stderr.splitlines()[-1]

--- a/osa/scripts/tests/test_osa_scripts.py
+++ b/osa/scripts/tests/test_osa_scripts.py
@@ -340,7 +340,7 @@ def test_observation_finished():
 
 def test_no_runs_found():
     output = sp.run(
-        ["sequencer", "-s", "-d", "2020-01-25", "LST1"], text=True, stdout=sp.PIPE, stderr=sp.PIPE
+        ["sequencer", "-s", "-d", "2020-05-05", "LST1"], text=True, stdout=sp.PIPE, stderr=sp.PIPE
     )
     assert output.returncode == 0
     assert "No runs found for this date. Nothing to do. Exiting." in output.stderr.splitlines()[-1]


### PR DESCRIPTION
instead of copying the DRS4 and PEDCALIB runs that need to be use to analyze those data into the run summary file of the day