### PR TITLE
Reduce the maximum number of pending jobs to continue launching gain_…

### DIFF
--- a/osa/scripts/gain_selection.py
+++ b/osa/scripts/gain_selection.py
@@ -60,7 +60,7 @@ def apply_gain_selection(date: str, output_basedir: Path = None):
 
     for run in data_runs:
         # Check slurm queue status and sleep for a while to avoid overwhelming the queue
-        check_job_status_and_wait()
+        check_job_status_and_wait(max_jobs=1500)
 
         # Avoid running jobs while it is still night time
         wait_for_daytime()

--- a/osa/scripts/gain_selection.py
+++ b/osa/scripts/gain_selection.py
@@ -13,7 +13,8 @@ import click
 from astropy.table import Table
 from lstchain.paths import run_info_from_filename, parse_r0_filename
 
-from osa.scripts.reprocessing import get_list_of_dates, check_job_status_and_wait, wait_for_daytime
+from osa.scripts.reprocessing import get_list_of_dates, check_job_status_and_wait
+from osa.utils.utils import wait_for_daytime
 from osa.utils.logging import myLogger
 from osa.job import get_sacct_output, FORMAT_SLURM
 
@@ -63,7 +64,7 @@ def apply_gain_selection(date: str, output_basedir: Path = None):
         check_job_status_and_wait(max_jobs=1500)
 
         # Avoid running jobs while it is still night time
-        wait_for_daytime()
+        wait_for_daytime(start=12, end=18)
 
         run_id = run["run_id"]
         ref_time = run["dragon_reference_time"]
@@ -120,7 +121,7 @@ def apply_gain_selection(date: str, output_basedir: Path = None):
 
     for run in calib_runs:
         # Avoid copying files while it is still night time
-        wait_for_daytime()
+        wait_for_daytime(start=12, end=18)
 
         run_id = run["run_id"]
         r0_files = r0_dir.glob(f"LST-1.?.Run{run_id:05d}.????.fits.fz")

--- a/osa/scripts/reprocessing.py
+++ b/osa/scripts/reprocessing.py
@@ -47,9 +47,9 @@ def run_script(
     sp.run(cmd)
 
 
-def check_job_status_and_wait():
+def check_job_status_and_wait(max_jobs=2500):
     """Check the status of the jobs in the queue and wait for them to finish."""
-    while number_of_pending_jobs() > 2500:
+    while number_of_pending_jobs() > max_jobs:
         log.info("Waiting 2 hours for slurm queue to decrease...")
         time.sleep(7200)
 

--- a/osa/scripts/reprocessing.py
+++ b/osa/scripts/reprocessing.py
@@ -61,16 +61,6 @@ def get_list_of_dates(dates_file):
     return list_of_dates
 
 
-def wait_for_daytime():
-    """
-    Check every hour if it is still nighttime
-    to not running jobs while it is still night.
-    """
-    while time.localtime().tm_hour <= 6 or time.localtime().tm_hour >= 18:
-        log.info("Waiting for sunrise to not interfere with the data-taking. Sleeping.")
-        time.sleep(3600)
-
-
 @click.command()
 @click.option("--no-dl2", is_flag=True, help="Do not run the DL2 step.")
 @click.option("--no-calib", is_flag=True, help="Do not run the calibration step.")

--- a/osa/scripts/reprocessing.py
+++ b/osa/scripts/reprocessing.py
@@ -9,6 +9,7 @@ import click
 
 from osa.configs.config import DEFAULT_CFG
 from osa.utils.logging import myLogger
+from osa.utils.utils import wait_for_daytime
 
 log = myLogger(logging.getLogger(__name__))
 

--- a/osa/utils/utils.py
+++ b/osa/utils/utils.py
@@ -4,6 +4,7 @@
 import inspect
 import logging
 import os
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from socket import gethostname
@@ -36,6 +37,7 @@ __all__ = [
     "is_night_time",
     "cron_lock",
     "example_seq",
+    "wait_for_daytime",
 ]
 
 log = myLogger(logging.getLogger(__name__))
@@ -314,3 +316,13 @@ def example_seq():
 def cron_lock(tel) -> Path:
     """Create a lock file for the cron jobs."""
     return osa.paths.analysis_path(tel) / "cron.lock"
+
+
+def wait_for_daytime(start=8, end=18):
+    """
+    Check every hour if it is still nighttime
+    to not running jobs while it is still night.
+    """
+    while time.localtime().tm_hour <= start or time.localtime().tm_hour >= end:
+        log.info("Waiting for sunrise to not interfere with the data-taking. Sleeping.")
+        time.sleep(3600)


### PR DESCRIPTION
…sel jobs. Also, maybe we could launch the gain selection script later so that it doesn't interfere with the lstosa processing? Maybe by changing the hours in the function "wait_for_daytime" of reprocessing.py?