### PR TITLE
Use stdlib importlib instead of importlib_resources

### DIFF
--- a/osa/configs/config.py
+++ b/osa/configs/config.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from pathlib import Path
 
-from importlib_resources import files
+from importlib.resources import files
 
 from osa.configs import options
 from osa.utils.logging import myLogger


### PR DESCRIPTION
since we are forcing to use python >= 3.9 we can drop the usage of importlib_resources