### PR TITLE
Bump lstchain version in pyproject and conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - ctapipe_io_lst=0.22
   - ctaplot~=0.6.4
   - pyirf=0.8
-  - lstchain~=0.10.0
+  - lstchain>=0.10.5
   - tenacity
   # dev dependencies
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - protobuf=3.20
   - ctapipe_io_lst=0.22
   - ctaplot~=0.6.4
-  - pyirf=0.8
+  - pyirf~=0.10
   - lstchain>=0.10.5
   - tenacity
   # dev dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "astropy~=5.0",
-    "lstchain~=0.10.0",
+    "lstchain>=0.10.5",
     "matplotlib~=3.7",
     "numpy",
     "pandas",


### PR DESCRIPTION
CI is continuously failing because is still installing the v0.10.4 which is not compatible because of the filter wheel find function update.

This should be merged before #264 

EDIT: the problem was that in the env yml pyirf was ping to v0.8.0, preventing the installation of lstchain > 0.10.4