### PR TITLE
Undo the possible symlink to longterm file before making the new one

### DIFF
--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -369,4 +369,5 @@ def create_longterm_symlink():
     latest_version_file = get_latest_version_file(all_longterm_files)
 
     log.info("Symlink the latest version longterm DL1 datacheck file in the common directory.")
+    linked_longterm_file.unlink()
     linked_longterm_file.symlink_to(latest_version_file)

--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -369,5 +369,5 @@ def create_longterm_symlink():
     latest_version_file = get_latest_version_file(all_longterm_files)
 
     log.info("Symlink the latest version longterm DL1 datacheck file in the common directory.")
-    linked_longterm_file.unlink()
+    linked_longterm_file.unlink(missing_ok=True)
     linked_longterm_file.symlink_to(latest_version_file)


### PR DESCRIPTION
After testing lstosa v0.10.9 with a night that was already processed with v0.9, I got an error due to an already existent link to the longterm file in the global directory "all", so I add a line to unlink this file before making the new symlink.