### PR TITLE
Wait until the longterm datacheck file is created to make the link

### DIFF
--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -362,7 +362,11 @@ def get_latest_version_file(longterm_files: List[str]) -> Path:
 
 
 def is_job_completed(job_id: str):
-    """Wait until the SLURM job corresponding to job_id finishes."""
+    """
+    Check whether SLURM job `job_id` has finished.
+    
+    It keeps checking every 10 minutes for one our.
+    """
     n_max = 10
     n = 0
     while n < n_max:
@@ -374,7 +378,7 @@ def is_job_completed(job_id: str):
         n += 1
         log.debug(f"Job {job_id} is not completed yet, checking again in 10 minutes...")
         time.sleep(600)  # wait 10 minutes to check again
-    log.info(f"The maximum number of checks of job {job_id} was reached, job {job_id} did not finish succesfully.")
+    log.info(f"The maximum number of checks of job {job_id} was reached, job {job_id} did not finish succesfully yet.")
     return False
 
 

--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -378,18 +378,25 @@ def is_job_completed(job_id: str):
     return False
 
 
-def create_longterm_symlink(cherenkov_job_id: str):
+def create_longterm_symlink(cherenkov_job_id: str = None):
     """If the created longterm DL1 datacheck file corresponds to the latest 
     version available, make symlink to it in the "all" common directory."""
-    if is_job_completed(cherenkov_job_id):
+    if not cherenkov_job_id or is_job_completed(cherenkov_job_id):
         nightdir = utils.date_to_dir(options.date)
         longterm_dir = Path(cfg.get("LST1", "LONGTERM_DIR"))
         linked_longterm_file = longterm_dir / f"night_wise/all/DL1_datacheck_{nightdir}.h5"
         all_longterm_files = longterm_dir.rglob(f"v*/{nightdir}/DL1_datacheck_{nightdir}.h5")
         latest_version_file = get_latest_version_file(all_longterm_files)
-
         log.info("Symlink the latest version longterm DL1 datacheck file in the common directory.")
         linked_longterm_file.unlink(missing_ok=True)
         linked_longterm_file.symlink_to(latest_version_file)
     else:
         log.warning(f"Job {cherenkov_job_id} (lstchain_cherenkov_transparency) did not finish successfully.")
+
+def dl1_datacheck_longterm_file_exits(): -> bool
+    """Return true if the longterm DL1 datacheck file was already produced."""
+    nightdir = utils.date_to_dir(options.date)
+    longterm_dir = Path(cfg.get("LST1", "LONGTERM_DIR"))
+    longterm_file = longterm_dir / options.prod_id / nightdir / f"DL1_datacheck_{nightdir}.h5"
+    return longterm_file.exists()
+

--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -393,7 +393,7 @@ def create_longterm_symlink(cherenkov_job_id: str = None):
     else:
         log.warning(f"Job {cherenkov_job_id} (lstchain_cherenkov_transparency) did not finish successfully.")
 
-def dl1_datacheck_longterm_file_exits(): -> bool
+def dl1_datacheck_longterm_file_exits() -> bool:
     """Return true if the longterm DL1 datacheck file was already produced."""
     nightdir = utils.date_to_dir(options.date)
     longterm_dir = Path(cfg.get("LST1", "LONGTERM_DIR"))

--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -361,7 +361,7 @@ def get_latest_version_file(longterm_files: List[str]) -> Path:
     )
 
 
-def wait_for_job_completion(job_id: str):
+def is_job_completed(job_id: str):
     """Wait until the SLURM job corresponding to job_id finishes."""
     n_max = 10
     n = 0
@@ -381,7 +381,7 @@ def wait_for_job_completion(job_id: str):
 def create_longterm_symlink(cherenkov_job_id: str):
     """If the created longterm DL1 datacheck file corresponds to the latest 
     version available, make symlink to it in the "all" common directory."""
-    if wait_for_job_completion(cherenkov_job_id):
+    if is_job_completed(cherenkov_job_id):
         nightdir = utils.date_to_dir(options.date)
         longterm_dir = Path(cfg.get("LST1", "LONGTERM_DIR"))
         linked_longterm_file = longterm_dir / f"night_wise/all/DL1_datacheck_{nightdir}.h5"

--- a/src/osa/scripts/closer.py
+++ b/src/osa/scripts/closer.py
@@ -158,8 +158,6 @@ def ask_for_closing():
 def post_process(seq_tuple):
     """Set of last instructions."""
     seq_list = seq_tuple[1]
-
-    a=False
     
     if dl1_datacheck_longterm_file_exits() and not options.test:
         create_longterm_symlink()

--- a/src/osa/scripts/closer.py
+++ b/src/osa/scripts/closer.py
@@ -159,7 +159,9 @@ def post_process(seq_tuple):
     """Set of last instructions."""
     seq_list = seq_tuple[1]
 
-    if dl1_datacheck_longterm_file_exits():
+    a=False
+    
+    if dl1_datacheck_longterm_file_exits() and not options.test:
         create_longterm_symlink()
 
     else:


### PR DESCRIPTION
Currently, autocloser is trying to make the symlink of the file right after the cherenkov_transparency script is launched, and it fails because the file has not yet been created. I put long times to wait for the job completion because nowadays there are many jobs running in the cluster, and many of them stay in PENDING status for a long time until they start running. 

EDIT:

> The first time closer runs it will go through the else, and wait to see if all the jobs are finished (until the hour), if so, the flag is created. If it is not closed after that hour, there is no nightfinished flag. Then closer runs again, first it checks that the longterm file exists, if it does it goes to the job completion check directly and tries to close again.