### PR TITLE
Add argument to allow the selection of the tool for the gain selection

### DIFF
--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -24,7 +24,7 @@ log = myLogger(logging.getLogger(__name__))
 
 PATH = "PATH=/fefs/aswg/software/offline_dvr/bin:$PATH"
 
-parser = argparse.ArgumentParser(add_help=False)
+parser = argparse.ArgumentParser()
 parser.add_argument(
         "--check",                                                                                       
         action="store_true",
@@ -50,13 +50,14 @@ parser.add_argument(
         "--date",                                                                                        
         default=None,
         type=str,
-        help="Night to apply the gain selection",
+        help="Night to apply the gain selection in YYYYMMDD format",
 )                                                                                                        
 parser.add_argument(                                                                                     
         "-l",                                                                                            
         "--dates-file",
         default=None,
-        help="List of dates to apply the gain selection",
+        help="List of dates to apply the gain selection. The input file should list"
+        "the dates in the format YYYYMMDD, one date per line.",
 )
 parser.add_argument(                                                                                     
         "-o",                                                                                            

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -85,7 +85,7 @@ parser.add_argument(
         "--tool",
         type=str,
         default=None,
-        help="Choose tool to apply the gain selection. Possible options are: lst_dvr (by default used for dates "
+        help="Choose tool to apply the gain selection regardless the date. Possible options are: lst_dvr (by default used for dates "
         "previous to 20231205) and lstchain_r0_to_r0g (by default used for dates later than 20231205).",
 )
 


### PR DESCRIPTION
By default, lstchain_r0_to_r0g will be used for dates later than 20231205 and lst_dvr for dates previous to it. But if we want to use e.g. lstchain_r0_to_r0g for a date previous to 20231205, we can do it now using the argument "tool". This is necessary for some days of November of 2023, in which some data was taken with EvBV6. 