### PR TITLE
Improvements for gain selection automation

### DIFF
--- a/src/osa/configs/sequencer.cfg
+++ b/src/osa/configs/sequencer.cfg
@@ -72,8 +72,8 @@ electron: /path/to/DL2/electron_mc_testing.h5
 PARTITION_PEDCALIB: short, long
 PARTITION_DATA: short, long
 MEMSIZE_PEDCALIB: 3GB
-MEMSIZE_DATA: 16GB
-MEMSIZE_GAINSEL: 15GB
+MEMSIZE_DATA: 6GB
+MEMSIZE_GAINSEL: 2GB
 WALLTIME: 1:15:00
 # Days from current day up to which the jobs are fetched from the queue.
 # Default is None (left empty).

--- a/src/osa/configs/sequencer.cfg
+++ b/src/osa/configs/sequencer.cfg
@@ -55,6 +55,7 @@ dl1_to_dl2: lstchain_dl1_to_dl2
 dl1a_config: /software/lstchain/data/lstchain_standard_config.json
 store_image_dl1ab: True
 merge_dl1_datacheck: True
+use_ff_heuristic_gain_selection: False
 dl1b_config: /software/lstchain/data/lstchain_standard_config.json
 dl2_config: /software/lstchain/data/lstchain_standard_config.json
 rf_models: /data/models/prod5/zenith_20deg/20201023_v0.6.3

--- a/src/osa/job.py
+++ b/src/osa/job.py
@@ -819,7 +819,7 @@ def update_sequence_state(sequence, filtered_job_info: pd.DataFrame) -> None:
 def job_finished_in_timeout(job_id) -> bool:
     """Return True if the input job_id finished in TIMEOUT state."""
     job_status = get_sacct_output(run_sacct(job_id=job_id))["State"]
-    if job_status.item() == "TIMEOUT":
+    if job_id and job_status.item() == "TIMEOUT":
         return True
     else:
         return False

--- a/src/osa/job.py
+++ b/src/osa/job.py
@@ -814,3 +814,12 @@ def update_sequence_state(sequence, filtered_job_info: pd.DataFrame) -> None:
         sequence.exit = "0:15"
     elif any("RUNNING" in job for job in filtered_job_info.State):
         sequence.state = "RUNNING"
+
+
+def job_finished_in_timeout(job_id) -> bool:
+    """Return True if the input job_id finished in TIMEOUT state."""
+    job_status = get_sacct_output(run_sacct(job_id=job_id))["State"]
+    if job_status == "TIMEOUT":
+        return True
+    else:
+        return False

--- a/src/osa/job.py
+++ b/src/osa/job.py
@@ -653,7 +653,7 @@ def get_squeue_output(squeue_output: StringIO) -> pd.DataFrame:
     return df
 
 
-def run_sacct(job_id=None) -> StringIO:
+def run_sacct(job_id: str = None) -> StringIO:
     """Run sacct to obtain the job information."""
     if shutil.which("sacct") is None:
         log.warning("No job info available since sacct command is not available")

--- a/src/osa/job.py
+++ b/src/osa/job.py
@@ -816,7 +816,7 @@ def update_sequence_state(sequence, filtered_job_info: pd.DataFrame) -> None:
         sequence.state = "RUNNING"
 
 
-def job_finished_in_timeout(job_id) -> bool:
+def job_finished_in_timeout(job_id: str) -> bool:
     """Return True if the input job_id finished in TIMEOUT state."""
     job_status = get_sacct_output(run_sacct(job_id=job_id))["State"]
     if job_id and job_status.item() == "TIMEOUT":

--- a/src/osa/job.py
+++ b/src/osa/job.py
@@ -819,7 +819,7 @@ def update_sequence_state(sequence, filtered_job_info: pd.DataFrame) -> None:
 def job_finished_in_timeout(job_id) -> bool:
     """Return True if the input job_id finished in TIMEOUT state."""
     job_status = get_sacct_output(run_sacct(job_id=job_id))["State"]
-    if job_status == "TIMEOUT":
+    if job_status.item() == "TIMEOUT":
         return True
     else:
         return False

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from osa.configs import options
 from osa.configs.config import cfg
-from osa.job import historylevel, get_sacct_output, run_sacct
+from osa.job import historylevel, get_sacct_output
 from osa.workflow.stages import AnalysisStage
 from osa.provenance.capture import trace
 from osa.utils.cliopts import data_sequence_cli_parsing

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -314,7 +314,7 @@ def main():
     else:
         log.setLevel(logging.INFO)
 
-    if is_datasequence_running(run_number):
+    if not options.simulate and is_datasequence_running(run_number):
         log.info(
             "Jobs launched by datasequence are still running or pending for"
             f"run {run_number}, try again later."

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -286,11 +286,17 @@ def dl1_to_dl2(run_str: str) -> int:
 
 
 def is_datasequence_running(run_str: str) -> bool:
-    """Return True if any datasequence jobs are running or pending for the given run number."""
+    """Return True if any datasequence jobs are running or pending for the given run number.
+    
+    Parameters
+    ----------
+    run_str : str
+        Run number and subrun number in the format XXXXX.XXXX
+    """
     sacct_output = run_sacct()
     sacct_info = get_sacct_output(sacct_output)
-    jobs_run = sacct_info[sacct_info["JobName"]=="LST1_"+run_str[:5]]
-    if jobs_run:
+    queued_jobs = sacct_info[sacct_info["JobName"]=="LST1_"+run_str[:5]]
+    if queued_jobs:
         return True
     else: 
         return False

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from osa.configs import options
 from osa.configs.config import cfg
-from osa.job import historylevel, get_sacct_output
+from osa.job import historylevel
 from osa.workflow.stages import AnalysisStage
 from osa.provenance.capture import trace
 from osa.utils.cliopts import data_sequence_cli_parsing

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -289,7 +289,7 @@ def is_datasequence_running(run_str: str) -> bool:
     """Return True if any datasequence jobs are running for the given run number."""
     sacct_output = run_sacct()
     sacct_info = get_sacct_output(sacct_output)
-    jobs_run = sacct_info[sacct_info["JobName"]=="LST1_"+run_number]
+    jobs_run = sacct_info[sacct_info["JobName"]=="LST1_"+run_str[:5]]
     if jobs_run:
         return True
     else: 

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -286,7 +286,7 @@ def dl1_to_dl2(run_str: str) -> int:
 
 
 def is_datasequence_running(run_str: str) -> bool:
-    """Return True if any datasequence jobs are running for the given run number."""
+    """Return True if any datasequence jobs are running or pending for the given run number."""
     sacct_output = run_sacct()
     sacct_info = get_sacct_output(sacct_output)
     jobs_run = sacct_info[sacct_info["JobName"]=="LST1_"+run_str[:5]]

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -285,23 +285,6 @@ def dl1_to_dl2(run_str: str) -> int:
     return analysis_step.rc
 
 
-def is_datasequence_running(run_str: str) -> bool:
-    """Return True if any datasequence jobs are running or pending for the given run number.
-    
-    Parameters
-    ----------
-    run_str : str
-        Run number and subrun number in the format XXXXX.XXXX
-    """
-    sacct_output = run_sacct()
-    sacct_info = get_sacct_output(sacct_output)
-    queued_jobs = sacct_info[sacct_info["JobName"]=="LST1_"+run_str[:5]]
-    if queued_jobs:
-        return True
-    else: 
-        return False
-
-
 def main():
     """Performs the analysis steps to convert raw data into DL2 files."""
     (

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -316,8 +316,8 @@ def main():
 
     if is_datasequence_running(run_number):
         log.info(
-            f"Jobs launched by datasequence are still running or pending for"
-            "run {run_number}, try again later."
+            "Jobs launched by datasequence are still running or pending for"
+            f"run {run_number}, try again later."
         )
         return
 

--- a/src/osa/scripts/datasequence.py
+++ b/src/osa/scripts/datasequence.py
@@ -314,26 +314,18 @@ def main():
     else:
         log.setLevel(logging.INFO)
 
-    if not options.simulate and is_datasequence_running(run_number):
-        log.info(
-            "Jobs launched by datasequence are still running or pending for"
-            f"run {run_number}, try again later."
-        )
-        return
-
-    else:
-        # Run the routine piping all the analysis steps
-        rc = data_sequence(
-            calibration_file,
-            drs4_ped_file,
-            time_calibration_file,
-            systematic_correction_file,
-            drive_log_file,
-            run_summary_file,
-            pedestal_ids_file,
-            run_number,
-        )
-        sys.exit(rc)
+    # Run the routine piping all the analysis steps
+    rc = data_sequence(
+        calibration_file,
+        drs4_ped_file,
+        time_calibration_file,
+        systematic_correction_file,
+        drive_log_file,
+        run_summary_file,
+        pedestal_ids_file,
+        run_number,
+    )
+    sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -429,7 +429,7 @@ def check_failed_jobs(date: datetime):
     summary_table = run_summary_table(date)
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
     failed_runs = []
-    warnings = []
+    warnings_in_logs = []
 
     for run in data_runs:
         run_id = run["run_id"]
@@ -439,9 +439,9 @@ def check_failed_jobs(date: datetime):
             failed_runs.append(run)
 
         if not check_warnings_in_logs(date, run_id):
-            warnings.append(run)
+            warnings_in_logs.append(run)
 
-    if failed_runs or warnings:
+    if failed_runs or warnings_in_logs:
         log.warning(f"Gain selection did not finish successfully for {date_to_iso(date)}, cannot create the flag file.")
         return
 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -426,6 +426,11 @@ def check_failed_jobs(date: datetime):
     """Search for failed jobs in the log directory."""
 
     summary_table = run_summary_table(date)
+
+    if len(summary_table) == 0:
+        log.warning(f"No runs are found in the run summary of {date_to_iso(date)}. Nothing to do. Exiting.")
+        sys.exit(0)
+        
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
     failed_runs = []
     warnings_in_logs = []

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -415,11 +415,8 @@ def check_warnings_in_logs(date: datetime, run_id: int) -> bool:
     for file in log_files:
         content = file.read_text().splitlines()
         for line in content:
-            if "WARNING - You should use heuristic identification of FF events!" in line:
-                log.warning(f"You should use heuristic identification of FF events for run {run_id}!")
-                return False
-
-    return True
+            if "FlatField(FF)-like events are not tagged as FF" in line:
+                log.warning(f"Warning for run {run_id}: {line}")
 
 
 def check_failed_jobs(date: datetime):
@@ -433,19 +430,16 @@ def check_failed_jobs(date: datetime):
         
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
     failed_runs = []
-    warnings_in_logs = []
 
     for run in data_runs:
         run_id = run["run_id"]
+        check_warnings_in_logs(date, run_id)
         
         if not check_gainsel_jobs_runwise(date, run_id):
             log.warning(f"Gain selection did not finish successfully for run {run_id}.")
             failed_runs.append(run)
 
-        if not check_warnings_in_logs(date, run_id):
-            warnings_in_logs.append(run)
-
-    if failed_runs or warnings_in_logs:
+    if failed_runs:
         log.warning(f"Gain selection did not finish successfully for {date_to_iso(date)}, cannot create the flag file.")
         return
 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -417,8 +417,8 @@ def check_warnings_in_logs(date: datetime, run_id: int) -> bool:
     for file in log_files:
         content = file.read_text().splitlines()
         for line in content:
-            if "WARNING" in line:
-                log.warning(f"There is a warning in the log files of run {run_id}: {line}")
+            if "WARNING - You should use heuristic identification of FF events!" in line:
+                log.warning(f"You should use heuristic identification of FF events for run {run_id}!")
                 return False
 
     return True

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -396,7 +396,8 @@ def check_gainsel_jobs_runwise(date: datetime, run_id: int) -> bool:
                 log.debug(f"Gain selection finished successfully for run {run_id}.{subrun}")
         else:
             log.info(f"Gain selection is still running for run {run_id}.{subrun}")
- 
+            return False
+            
     if failed_subruns:
         log.warning(f"{date_to_iso(date)}: Some gain selection jobs did not finish successfully for run {run_id}")
         return False

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -260,9 +260,7 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
         else:
             tool = "lstchain_r0_to_r0g"
 
-    run_summary_dir = Path(cfg.get("LST1", "RUN_SUMMARY_DIR"))
-    run_summary_file = run_summary_dir / f"RunSummary_{date}.ecsv"
-    summary_table = Table.read(run_summary_file)
+    summary_table = run_summary_table(date)
 
     if len(summary_table) == 0:
         log.warning(f"No runs are found in the run summary of {date}. Nothing to do. Exiting.")
@@ -309,6 +307,14 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
 
             	for file in r0_files:
                     sp.run(["cp", file, output_dir])
+
+
+def run_summary_table(date: str) -> Table:
+    """Return a table with all the runs of a given date."""
+    run_summary_dir = Path(cfg.get("LST1", "RUN_SUMMARY_DIR"))
+    run_summary_file = run_summary_dir / f"RunSummary_{date}.ecsv"
+    summary_table = Table.read(run_summary_file)
+    return summary_table
 
 
 def get_last_job_id(run_id: str, subrun: str, log_dir: Path) -> int:
@@ -407,9 +413,7 @@ def check_gainsel_jobs_runwise(date: str, run_id: int) -> bool:
 def check_failed_jobs(date: str):
     """Search for failed jobs in the log directory."""
 
-    run_summary_dir = Path(cfg.get("LST1", "RUN_SUMMARY_DIR"))
-    run_summary_file = run_summary_dir / f"RunSummary_{date}.ecsv"
-    summary_table = Table.read(run_summary_file)
+    summary_table = run_summary_table(date)
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
 
     for run in data_runs:

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -137,7 +137,7 @@ def get_sbatch_script(
         
     elif tool == "lstchain_r0_to_r0g":
         cmd = f"lstchain_r0_to_r0g --R0-file={input_file} --output-dir={output_dir} --log={log_file}"
-        if not cfg.get("lstchain", "use_ff_heuristic_gain_selection"): 
+        if not cfg.getboolean("lstchain", "use_ff_heuristic_gain_selection"): 
             cmd += " --no-flatfield-heuristic"
         sbatch_script += dedent(cmd)
 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -291,7 +291,8 @@ def apply_gain_selection(date: datetime, start: int, end: int, tool: str = None,
         # Avoid running jobs while it is still night time
         wait_for_daytime(start, end)
 
-        launch_gainsel_for_data_run(date, run, output_dir, r0_dir, log_dir, tool, simulate)
+        if not is_closed(date, run["run_id"]):
+            launch_gainsel_for_data_run(date, run, output_dir, r0_dir, log_dir, tool, simulate)
 
     calib_runs = summary_table[summary_table["run_type"] != "DATA"]
     log.info(f"Found {len(calib_runs)} NO-DATA runs")

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -92,7 +92,7 @@ def get_sbatch_script(
     run_id, subrun, input_file, output_dir, log_dir, log_file, ref_time, ref_counter, module, ref_source, tool
 ):
     """Build the sbatch job pilot script for running the gain selection."""
-    
+    mem_per_job = cfg.get("SLURM", "MEMSIZE_GAINSEL")
     sbatch_script = dedent(
             f"""\
         #!/bin/bash
@@ -101,6 +101,7 @@ def get_sbatch_script(
         #SBATCH -o "gain_selection_{run_id:05d}_{subrun:04d}_%j.log"
         #SBATCH --job-name "gain_selection_{run_id:05d}"
         #SBATCH --partition=short,long
+        #SBATCH --mem={mem_per_job}
         """
         )
     
@@ -114,11 +115,9 @@ def get_sbatch_script(
         )
         
     elif tool == "lstchain_r0_to_r0g":
-        mem_per_job = cfg.get("SLURM", "MEMSIZE_GAINSEL")
+        
         sbatch_script += dedent(
             f"""
-        #SBATCH --mem={mem_per_job}
-
         lstchain_r0_to_r0g --R0-file={input_file} --output-dir={output_dir} --log={log_file} --no-flatfield-heuristic
         """
         )
@@ -247,7 +246,7 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
 
     base_dir = Path(cfg.get("LST1", "BASE"))
     output_dir = base_dir / f"R0G/{date}"
-    log_dir = base_dir / f"R0G/log{date}"
+    log_dir = base_dir / f"R0G/log/{date}"
     output_dir.mkdir(parents=True, exist_ok=True)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / f"r0_to_r0g_{date}.log"

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -16,7 +16,7 @@ from osa.scripts.reprocessing import get_list_of_dates, check_job_status_and_wai
 from osa.utils.utils import wait_for_daytime
 from osa.utils.logging import myLogger
 from osa.utils.iofile import append_to_file
-from osa.job import get_sacct_output, run_sacct, job_finihsed_in_timeout
+from osa.job import get_sacct_output, run_sacct, job_finished_in_timeout
 from osa.configs.config import cfg
 from osa.paths import DEFAULT_CFG
 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -336,7 +336,7 @@ def run_already_copied(date: str, run_id: int) -> bool:
 
 
 def GainSel_flag_file(date: str) -> Path:
-    """Return the name of the gain selection flag file."""
+    """Return the path to the file indicating the completion of the gain selection stage."""
     filename = cfg.get("LSTOSA", "gain_selection_check")
     GainSel_dir = Path(cfg.get("LST1", "GAIN_SELECTION_FLAG_DIR"))
     flagfile = GainSel_dir / date / filename

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -276,7 +276,6 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
     log_dir = base_dir / f"R0G/log/{date}"
     log_file = log_dir / f"r0_to_r0g_{date}.log"
     if not simulate:
-        output_dir.mkdir(parents=True, exist_ok=True)
         log_dir.mkdir(parents=True, exist_ok=True)
 
     for run in data_runs:
@@ -385,7 +384,7 @@ def check_gainsel_jobs_runwise(date: str, run_id: int) -> bool:
     failed_subruns = []
     log.info(f"Checking all history files of run {run_id}")
     
-    for file in list(history_files):
+    for file in history_files:
         match = re.search(f"gain_selection_{run_id:05d}.(\d+).history", str(file))
         subrun = match.group(1)
         if file.read_text() != "":

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -279,6 +279,7 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
     log_dir = base_dir / f"R0G/log/{date}"
     log_file = log_dir / f"r0_to_r0g_{date}.log"
     if not simulate:
+        output_dir.mkdir(parents=True, exist_ok=True)
         log_dir.mkdir(parents=True, exist_ok=True)
 
     for run in data_runs:

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -150,9 +150,10 @@ def launch_gainsel_for_data_run(
     date: datetime, run: Table, output_dir: Path, r0_dir: Path, log_dir: Path, tool: str, simulate: bool = False
     ):
     """
-    Create the gain selection sbatch script and launch it for a given run. Runs from before 20231205
-    without UCTS or TIB info are directly copied to the final directory. Subruns that do not have 
-    four streams are also directly copied.
+    Create the gain selection sbatch script and launch it for a given run.
+    
+    Runs from before 20231205 without UCTS or TIB info are directly copied to the final directory.
+    Subruns that do not have four streams are also directly copied.
     """
     run_id = run["run_id"]
     ref_time = run["dragon_reference_time"]
@@ -167,11 +168,11 @@ def launch_gainsel_for_data_run(
         input_files = r0_dir.glob(f"LST-1.?.Run{run_id:05d}.????.fits.fz")
         
         if is_run_already_copied(date, run_id):
-            log.debug(f"The R0 files corresponding to run {run_id} have already been copied to the R0G directory.")
+            log.info(f"The R0 files corresponding to run {run_id} have already been copied to the R0G directory.")
         else:
             if not simulate:
                 for file in input_files:
-                    log.info(
+                    log.debug(
                         f"Run {run_id} does not have UCTS or TIB info, so gain selection cannot"
                         f"be applied. Copying directly the R0 files to {output_dir}."
                     )
@@ -192,7 +193,7 @@ def launch_gainsel_for_data_run(
 
             if len(r0_files) != 4:
                 if not simulate and not is_run_already_copied(date, run_id):
-                    log.info(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
+                    log.debug(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
                         f"selection cannot be applied. Copying directly the R0 files to {output_dir}.")
                     for file in r0_files:
                         sp.run(["cp", file, output_dir])
@@ -200,7 +201,7 @@ def launch_gainsel_for_data_run(
                     log.debug(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files. The R0 files"
                         f"have already been copied to {output_dir}.")
                 elif simulate:
-                    log.info(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
+                    log.debug(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
                         f"selection cannot be applied. Simulate copy of the R0 files directly to {output_dir}.")
 
             else:
@@ -210,7 +211,7 @@ def launch_gainsel_for_data_run(
                         update_history_file(run_id, subrun, log_dir, history_file)
 
                     if history_file.read_text() == "":   # history_file is empty
-                        log.info(f"Gain selection is still running for run {run_id:05d}.{subrun:04d}")
+                        log.debug(f"Gain selection is still running for run {run_id:05d}.{subrun:04d}")
                         continue
                     else:
                         gainsel_rc = history_file.read_text().splitlines()[-1][-1]
@@ -226,7 +227,7 @@ def launch_gainsel_for_data_run(
                             log.debug(f"Gain selection finished successfully for run {run_id:05d}.{subrun:04d},"
                                         "no additional jobs will be submitted for this subrun.") 
                 else:
-                    log.info("Creating and launching the sbatch scripts for the rest of the runs to apply gain selection")
+                    log.debug("Creating and launching the gain selection sbatch script for subrun {run_id:05d}.{subrun:04d}")
                     if not simulate:
                         log_file = log_dir / f"r0_to_r0g_{run_id:05d}.{subrun:04d}.log"
                         job_file = log_dir / f"gain_selection_{run_id:05d}.{subrun:04d}.sh"
@@ -504,7 +505,7 @@ def main():
             log.info(f"Checking gain selection status for date {date_to_iso(args.date)}")
             check_failed_jobs(args.date)
         else:
-            log.info(f"Applying gain selection to date {date_to_iso(args.date)}")
+            log.info(f"\nApplying gain selection to date {date_to_iso(args.date)}")
             apply_gain_selection(
                 args.date, 
                 args.start_time, 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -410,6 +410,7 @@ def check_gainsel_jobs_runwise(date: datetime, run_id: int) -> bool:
 
 def check_warnings_in_logs(date: datetime, run_id: int) -> bool:
     """Look for warnings in the log files created by lstchain_r0_to_r0g."""
+    base_dir = Path(cfg.get("LST1", "BASE"))
     log_dir = base_dir / f"R0G/log/{date_to_dir(date)}"
     log_files = log_dir.glob(f"r0_to_r0g_{run_id:05d}.*.log")
     for file in log_files:

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -423,7 +423,7 @@ def check_failed_jobs(date: datetime):
             failed_runs.append(run)
 
     if failed_runs:
-        log.info(f"Gain selection did not finish successfully for {date_to_iso(date)}, cannot create the flag file.")
+        log.warning(f"Gain selection did not finish successfully for {date_to_iso(date)}, cannot create the flag file.")
         return
 
     runs = summary_table["run_id"]

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -87,6 +87,13 @@ parser.add_argument(
         default=False,
         help="Simulate launching of the gain selection script. Dry run.",
 )
+parser.add_argument(
+        "-v",                                                                                      
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Activate debugging mode.",
+)
 
 def get_sbatch_script(
     run_id: str,
@@ -455,8 +462,12 @@ def main():
     script for each of them. The input file should list the dates in the format
     YYYYMMDD one date per line.
     """
-    log.setLevel(logging.INFO)
     args = parser.parse_args()
+    
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
 
     if args.date:
         if args.check:

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -497,11 +497,14 @@ def main():
         log.setLevel(logging.INFO)
 
     if args.date:
-        if args.check:
-            log.info(f"Checking gain selection status for date {args.date}")
+        if GainSel_finished(args.date):
+            log.warning(f"Gain selection already done for date {date_to_iso(args.date)}. Exiting.")
+            sys.exit(0)
+        elif args.check:
+            log.info(f"Checking gain selection status for date {date_to_iso(args.date)}")
             check_failed_jobs(args.date)
         else:
-            log.info(f"Applying gain selection to date {args.date}")
+            log.info(f"Applying gain selection to date {date_to_iso(args.date)}")
             apply_gain_selection(
                 args.date, 
                 args.start_time, 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -162,7 +162,7 @@ def launch_gainsel_for_data_run(
     if tool == "lst_dvr" and ref_source not in ["UCTS", "TIB"]:
         input_files = r0_dir.glob(f"LST-1.?.Run{run_id:05d}.????.fits.fz")
         
-        if run_already_copied(date, run_id):
+        if is_run_already_copied(date, run_id):
             log.debug(f"The R0 files corresponding to run {run_id} have already been copied to the R0G directory.")
         else:
             if not simulate:
@@ -187,12 +187,12 @@ def launch_gainsel_for_data_run(
             r0_files = glob.glob(f"{r0_dir}/LST-1.?.Run{run_id:05d}.{subrun:04d}.fits.fz")
 
             if len(r0_files) != 4:
-                if not simulate and not run_already_copied(date, run_id):
+                if not simulate and not is_run_already_copied(date, run_id):
                     log.info(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
                         f"selection cannot be applied. Copying directly the R0 files to {output_dir}.")
                     for file in r0_files:
                         sp.run(["cp", file, output_dir])
-                elif run_already_copied(date, run_id):
+                elif is_run_already_copied(date, run_id):
                     log.debug(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files. The R0 files"
                         f"have already been copied to {output_dir}.")
                 elif simulate:
@@ -295,7 +295,7 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
     for run in calib_runs:
         run_id = run["run_id"]
         
-        if run_already_copied(date, run_id):
+        if is_run_already_copied(date, run_id):
             log.info(f"The R0 files corresponding to run {run_id:05d} have already been copied, nothing to do.")
         else:
             log.info(f"Copying R0 files corresponding to run {run_id} directly to {output_dir}")
@@ -355,7 +355,7 @@ def update_history_file(run_id: str, subrun: str, log_dir: Path, history_file: P
             append_to_file(history_file, string_to_write)
 
 
-def run_already_copied(date: str, run_id: int) -> bool:
+def is_run_already_copied(date: str, run_id: int) -> bool:
     """Check if the R0 files of a given run have already been copied to the R0G directory."""
     base_dir = Path(cfg.get("LST1", "BASE"))
     r0_files = glob.glob(f"{base_dir}/R0/{date}/LST-1.?.Run{run_id:05d}.????.fits.fz")

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -11,7 +11,6 @@ import sys
 
 from astropy.table import Table
 from lstchain.paths import parse_r0_filename
-from ctapipe_io_lst import LSTEventSource
 from datetime import datetime
 
 from osa.scripts.reprocessing import get_list_of_dates, check_job_status_and_wait
@@ -429,23 +428,6 @@ def check_warnings_in_logs(date: datetime, run_id: int):
                 log.warning(f"Warning for run {run_id}: {line}")
 
 
-def check_R0G_files(date: datetime, run_id: int):
-    """Check if the produced R0G files can be correctly opened with ctapipe_io_lst."""
-    base_dir = Path(cfg.get("LST1", "BASE"))
-    r0g_files = glob.glob(f"{base_dir}/R0G/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
-    for file in r0g_files:
-        n_events = 10
-        try:
-            LSTEventSource(
-                input_url=file,
-                max_events=n_events,
-                apply_drs4_corrections=False,
-                pointing_information=False,
-            )
-        except AttributeError:
-            log.warning(f"File {file} cannot be opened with ctapipe_io_lst.")
-
-
 def check_failed_jobs(date: datetime):
     """Search for failed jobs in the log directory."""
 
@@ -465,8 +447,6 @@ def check_failed_jobs(date: datetime):
             if not check_gainsel_jobs_runwise(date, run_id):
                 log.warning(f"Gain selection did not finish successfully for run {run_id}.")
                 failed_runs.append(run)
-        else:
-            check_R0G_files(date, run_id)
 
     if failed_runs:
         log.warning(f"Gain selection did not finish successfully for {date_to_iso(date)}, cannot create the flag file.")

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -11,6 +11,7 @@ import sys
 
 from astropy.table import Table
 from lstchain.paths import parse_r0_filename
+from datetime import datetime
 
 from osa.scripts.reprocessing import get_list_of_dates, check_job_status_and_wait
 from osa.utils.utils import wait_for_daytime
@@ -19,6 +20,8 @@ from osa.utils.iofile import append_to_file
 from osa.job import get_sacct_output, run_sacct, job_finished_in_timeout
 from osa.configs.config import cfg
 from osa.paths import DEFAULT_CFG
+from osa.nightsummary.nightsummary import run_summary_table
+
 
 log = myLogger(logging.getLogger(__name__))
 
@@ -260,7 +263,7 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
         else:
             tool = "lstchain_r0_to_r0g"
 
-    summary_table = run_summary_table(date)
+    summary_table = run_summary_table(datetime.fromisoformat(date))
 
     if len(summary_table) == 0:
         log.warning(f"No runs are found in the run summary of {date}. Nothing to do. Exiting.")
@@ -306,14 +309,6 @@ def apply_gain_selection(date: str, start: int, end: int, tool: str = None, no_q
 
             	for file in r0_files:
                     sp.run(["cp", file, output_dir])
-
-
-def run_summary_table(date: str) -> Table:
-    """Return a table with all the runs of a given date."""
-    run_summary_dir = Path(cfg.get("LST1", "RUN_SUMMARY_DIR"))
-    run_summary_file = run_summary_dir / f"RunSummary_{date}.ecsv"
-    summary_table = Table.read(run_summary_file)
-    return summary_table
 
 
 def get_last_job_id(run_id: str, subrun: str, log_dir: Path) -> int:
@@ -412,7 +407,7 @@ def check_gainsel_jobs_runwise(date: str, run_id: int) -> bool:
 def check_failed_jobs(date: str):
     """Search for failed jobs in the log directory."""
 
-    summary_table = run_summary_table(date)
+    summary_table = run_summary_table(datetime.fromisoformat(date))
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
 
     for run in data_runs:

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -410,14 +410,18 @@ def check_failed_jobs(date: str):
 
     summary_table = run_summary_table(datetime.fromisoformat(date))
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
+    failed_runs = []
 
     for run in data_runs:
         run_id = run["run_id"]
         
         if not check_gainsel_jobs_runwise(date, run_id):
-            log.warning(f"Gain selection did not finish successfully for run {run_id}. Exiting...")
-            sys.exit(0)
+            log.warning(f"Gain selection did not finish successfully for run {run_id}.")
+            failed_runs.append(run)
 
+    if failed_runs:
+        log.info(f"Gain selection did not finish successfully for {date}, cannot create the flag file.")
+        return
 
     runs = summary_table["run_id"]
     missing_runs = []

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -14,7 +14,7 @@ from lstchain.paths import parse_r0_filename
 from datetime import datetime
 
 from osa.scripts.reprocessing import get_list_of_dates, check_job_status_and_wait
-from osa.utils.utils import wait_for_daytime
+from osa.utils.utils import wait_for_daytime, date_to_dir, date_to_iso
 from osa.utils.logging import myLogger
 from osa.utils.iofile import append_to_file
 from osa.utils.cliopts import valid_date

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -136,13 +136,11 @@ def get_sbatch_script(
         )
         
     elif tool == "lstchain_r0_to_r0g":
-        
-        sbatch_script += dedent(
-            f"""
-        lstchain_r0_to_r0g --R0-file={input_file} --output-dir={output_dir} --log={log_file} --no-flatfield-heuristic
-        """
-        )
-        
+        cmd = f"lstchain_r0_to_r0g --R0-file={input_file} --output-dir={output_dir} --log={log_file}"
+        if not cfg.get("lstchain", "use_ff_heuristic_gain_selection"): 
+            cmd += " --no-flatfield-heuristic"
+        sbatch_script += dedent(cmd)
+
     return sbatch_script
 
 

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -186,17 +186,18 @@ def launch_gainsel_for_data_run(
 
             r0_files = glob.glob(f"{r0_dir}/LST-1.?.Run{run_id:05d}.{subrun:04d}.fits.fz")
 
-            if len(r0_files) != 4 and not run_already_copied(date, run_id):
-                if not simulate:
+            if len(r0_files) != 4:
+                if not simulate and not run_already_copied(date, run_id):
                     log.info(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
-                        f"selection cannot be applied. Copying directly the R0 files to {output_dir}."
-                    )
+                        f"selection cannot be applied. Copying directly the R0 files to {output_dir}.")
                     for file in r0_files:
                         sp.run(["cp", file, output_dir])
-                else:
+                elif run_already_copied(date, run_id):
+                    log.debug(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files. The R0 files"
+                        f"have already been copied to {output_dir}.")
+                elif simulate:
                     log.info(f"Run {run_id:05d}.{subrun:04d} does not have 4 streams of R0 files, so gain"
-                        f"selection cannot be applied. Simulate copy of the R0 files directly to {output_dir}."
-                    )
+                        f"selection cannot be applied. Simulate copy of the R0 files directly to {output_dir}.")
 
             else:
                 history_file = log_dir / f"gain_selection_{run_id:05d}.{subrun:04d}.history"

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -436,7 +436,7 @@ def check_R0G_files(date: datetime, run_id: int):
     for file in r0g_files:
         n_events = 10
         try:
-            source = LSTEventSource(
+            LSTEventSource(
                 input_url=file,
                 max_events=n_events,
                 apply_drs4_corrections=False,

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -115,7 +115,7 @@ def single_process(telescope):
             log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
             sys.exit(0)
 
-        elif sequencer_finished(options.date) and not options.force:
+        elif is_sequencer_completed(options.date) and not options.force_submit:
             log.info(f"Sequencer already finished for date {date_to_iso(options.date)}. Exiting")
             sys.exit(0)
 

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -98,9 +98,9 @@ def single_process(telescope):
         log.warning("No runs found for this date. Nothing to do. Exiting.")
         sys.exit(0)
 
-    if not options.no_gainsel and not GainSel_finished(date_to_dir(options.date)):
+    if not options.no_gainsel and not GainSel_finished(options.date):
         log.info(
-            f"Gain selection did not finish successfully for date {options.date}."
+            f"Gain selection did not finish successfully for date {date_to_iso(options.date)}."
             "Try again later, once gain selection has finished."
         )
         sys.exit()

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -109,9 +109,9 @@ def single_process(telescope):
         log.info(f"Date {date_to_iso(options.date)} is already closed for {options.tel_id}")
         return sequence_list
 
-    if is_sequencer_running(options.date):
-        log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
-        sys.exit(0)
+    if not options.test and is_sequencer_running(options.date):
+            log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
+            sys.exit(0)
 
     # Build the sequences
     sequence_list = build_sequences(options.date)

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -333,13 +333,14 @@ def is_sequencer_running(date) -> bool:
 def sequencer_finished(date) -> bool:
     """Check if the jobs launched by sequencer are running or pending for the given date."""
     summary_table = run_summary_table(date)
+    data_runs = summary_table[summary_table["run_type"] == "DATA"]
     sacct_output = run_sacct()
     sacct_info = get_sacct_output(sacct_output)
 
-    for run in summary_table["run_id"]:
+    for run in data_runs["run_id"]:
         jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run}"]
         incomplete_jobs = jobs_run[(jobs_run["State"] != "COMPLETED")]
-        if len(incomplete_jobs) != 0:
+        if len(jobs_run) == 0 or len(incomplete_jobs) != 0:
             return False
 
     return True

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 from decimal import Decimal
+import datetime
 
 from osa import osadb
 from osa.configs import options

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -28,7 +28,7 @@ from osa.paths import analysis_path
 from osa.report import start
 from osa.utils.cliopts import sequencer_cli_parsing
 from osa.utils.logging import myLogger
-from osa.utils.utils import is_day_closed, gettag, date_to_iso, date_to_dir
+from osa.utils.utils import is_day_closed, gettag, date_to_iso
 from osa.veto import get_closed_list, get_veto_list
 from osa.scripts.gain_selection import GainSel_finished
 

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -331,7 +331,7 @@ def is_sequencer_running(date) -> bool:
     return False
 
 
-def sequencer_finished(date: datetime.datetime) -> bool:
+def is_sequencer_completed(date: datetime.datetime) -> bool:
     """Check if the jobs launched by sequencer are running or pending for the given date."""
     summary_table = run_summary_table(date)
     data_runs = summary_table[summary_table["run_type"] == "DATA"]

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -316,7 +316,7 @@ def output_matrix(matrix: list, padding_space: int):
         log.info(stringrow)
 
 
-def is_sequencer_running(date) -> bool:
+def is_sequencer_running(date: datetime.datetime) -> bool:
     """Check if the jobs launched by sequencer are running or pending for the given date."""
     summary_table = run_summary_table(date)
     sacct_output = run_sacct()

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -322,7 +322,7 @@ def is_sequencer_running(date) -> bool:
     sacct_info = get_sacct_output(sacct_output)
 
     for run in summary_table["run_id"]:
-        jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run}"]
+        jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run:05d}"]
         queued_jobs = jobs_run[(jobs_run["State"] == "RUNNING") | (jobs_run["State"] == "PENDING")]
         if len(queued_jobs) != 0:
             return True
@@ -338,7 +338,7 @@ def sequencer_finished(date: datetime.datetime) -> bool:
     sacct_info = get_sacct_output(sacct_output)
 
     for run in data_runs["run_id"]:
-        jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run}"]
+        jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run:05d}"]
         incomplete_jobs = jobs_run[(jobs_run["State"] != "COMPLETED")]
         if len(jobs_run) == 0 or len(incomplete_jobs) != 0:
             return False

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -110,8 +110,8 @@ def single_process(telescope):
         return sequence_list
 
     if not options.test and is_sequencer_running(options.date):
-            log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
-            sys.exit(0)
+        log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
+        sys.exit(0)
 
     # Build the sequences
     sequence_list = build_sequences(options.date)

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -340,6 +340,9 @@ def sequencer_finished(date: datetime.datetime) -> bool:
 
     for run in data_runs["run_id"]:
         jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run:05d}"]
+        if len(jobs_run["JobID"].unique())>1:
+            last_job_id = sorted(jobs_run["JobID"].unique())[-1]
+            jobs_run = sacct_info[sacct_info["JobID"]==last_job_id]
         incomplete_jobs = jobs_run[(jobs_run["State"] != "COMPLETED")]
         if len(jobs_run) == 0 or len(incomplete_jobs) != 0:
             return False

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -100,7 +100,7 @@ def single_process(telescope):
 
     if not options.no_gainsel and not GainSel_finished(options.date):
         log.info(
-            f"Gain selection did not finish successfully for date {date_to_iso(options.date)}."
+            f"Gain selection did not finish successfully for date {date_to_iso(options.date)}. "
             "Try again later, once gain selection has finished."
         )
         sys.exit()
@@ -109,7 +109,7 @@ def single_process(telescope):
         log.info(f"Date {date_to_iso(options.date)} is already closed for {options.tel_id}")
         return sequence_list
 
-    if not options.test and is_sequencer_running(options.date):
+    if not options.test and is_sequencer_running(options.date) and not options.simulate:
         log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
         sys.exit(0)
 

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -330,7 +330,7 @@ def is_sequencer_running(date) -> bool:
     return False
 
 
-def sequencer_finished(date) -> bool:
+def sequencer_finished(date: datetime.datetime) -> bool:
     """Check if the jobs launched by sequencer are running or pending for the given date."""
     summary_table = run_summary_table(date)
     data_runs = summary_table[summary_table["run_type"] == "DATA"]

--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -110,7 +110,7 @@ def single_process(telescope):
         return sequence_list
 
     if is_sequencer_running(options.date):
-        log.info(f"Sequencer is still running for date {options.date}. Try again later.")
+        log.info(f"Sequencer is still running for date {date_to_iso(options.date)}. Try again later.")
         sys.exit(0)
 
     # Build the sequences

--- a/src/osa/tests/test_jobs.py
+++ b/src/osa/tests/test_jobs.py
@@ -84,7 +84,7 @@ def test_scheduler_env_variables(sequence_list, running_analysis_dir):
         "#SBATCH --error=log/Run01807.%4a_jobid_%A.err",
         "#SBATCH --array=0-10",
         f'#SBATCH --partition={cfg.get("SLURM", "PARTITION_DATA")}',
-        "#SBATCH --mem-per-cpu=16GB",
+        "#SBATCH --mem-per-cpu=6GB",
         "#SBATCH --account=dpps",
     ]
 
@@ -125,7 +125,7 @@ def test_job_header_template(sequence_list, running_analysis_dir):
     #SBATCH --error=log/Run01807.%4a_jobid_%A.err
     #SBATCH --array=0-10
     #SBATCH --partition={cfg.get('SLURM', 'PARTITION_DATA')}
-    #SBATCH --mem-per-cpu=16GB
+    #SBATCH --mem-per-cpu=6GB
     #SBATCH --account=dpps"""
     )
     assert header == output_string2

--- a/src/osa/utils/cliopts.py
+++ b/src/osa/utils/cliopts.py
@@ -306,7 +306,7 @@ def sequencer_cli_parsing():
     options.no_calib = opts.no_calib
     options.no_dl2 = opts.no_dl2
     options.no_gainsel = opts.no_gainsel
-    options.force = opts.force
+    options.force_submit = opts.force_submit
 
     log.debug(f"the options are {opts}")
 

--- a/src/osa/utils/cliopts.py
+++ b/src/osa/utils/cliopts.py
@@ -282,7 +282,7 @@ def sequencer_argparser():
     )
     parser.add_argument(
         "-f",
-        "--force",
+        "--force-submit",
         action="store_true",
         default=False,
         help="Force sequencer to submit jobs"

--- a/src/osa/utils/cliopts.py
+++ b/src/osa/utils/cliopts.py
@@ -281,6 +281,13 @@ def sequencer_argparser():
         help="Do not check if the gain selection finished correctly (default False)",
     )
     parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Force sequencer to submit jobs"
+    )
+    parser.add_argument(
         "tel_id",
         choices=["ST", "LST1", "LST2", "all"],
         help="telescope identifier LST1, LST2, ST or all.",
@@ -299,6 +306,7 @@ def sequencer_cli_parsing():
     options.no_calib = opts.no_calib
     options.no_dl2 = opts.no_dl2
     options.no_gainsel = opts.no_gainsel
+    options.force = opts.force
 
     log.debug(f"the options are {opts}")
 


### PR DESCRIPTION
Main changes that have been made in this PR: 

- Write history files for each subrun (apart from the log files) + update them every time the gain selection script is launched
- Allow launching the gain selection script several times without launching the jobs that are already running again (if the history file exists and is empty for a given subrun, it means that the job is running for that run, so it doesn't launch it again)
- Change the check option so that it is done looking at the history files and not at the log files
- Add simulate option to the gain selection script
- Once the gain selection finishes correctly for all runs, the gain selection script is launched with the check option to see if there is any run missing that needs to be copied to R0G.
