### PR TITLE
Fix issue in function "timeout_in_sequencer"

### DIFF
--- a/src/osa/scripts/sequencer.py
+++ b/src/osa/scripts/sequencer.py
@@ -364,8 +364,9 @@ def timeout_in_sequencer(date: datetime.datetime) -> bool:
 
     for run in data_runs["run_id"]:
         jobs_run = sacct_info[sacct_info["JobName"]==f"LST1_{run:05d}"]
-        last_job_id = sorted(jobs_run["JobID"].unique())[-1]
-        jobs_run = sacct_info[sacct_info["JobID"]==last_job_id]
+        if len(jobs_run["JobID"].unique())>1:
+            last_job_id = sorted(jobs_run["JobID"].unique())[-1]
+            jobs_run = sacct_info[sacct_info["JobID"]==last_job_id]
         timeout_jobs = jobs_run[(jobs_run["State"] == "TIMEOUT")]
         if len(timeout_jobs) != 0:
             return True


### PR DESCRIPTION
If no jobs have been launched yet, sequencer fails because jobs_run is empty and this cannot be done: 
last_job_id = sorted(jobs_run["JobID"].unique())[-1]
So we can only do this if there is more than one job_id for a given run.