### PR TITLE
Allow to decide if the longterm symlink should be created or not

### DIFF
--- a/src/osa/configs/sequencer.cfg
+++ b/src/osa/configs/sequencer.cfg
@@ -66,6 +66,7 @@ merge_dl1_datacheck: True
 apply_catB_calibration: False
 apply_standard_dl1b_config: False
 use_ff_heuristic_gain_selection: False
+create_longterm_symlink: True
 dl1b_config: /software/lstchain/data/lstchain_standard_config.json
 dl2_config: /software/lstchain/data/lstchain_standard_config.json
 mc_prod: 20240918_v0.10.12_allsky_

--- a/src/osa/scripts/closer.py
+++ b/src/osa/scripts/closer.py
@@ -160,7 +160,8 @@ def post_process(seq_tuple):
     seq_list = seq_tuple[1]
     
     if dl1_datacheck_longterm_file_exits() and not options.test:
-        create_longterm_symlink()
+        if cfg.getboolean("lstchain", "create_longterm_symlink"):
+            create_longterm_symlink()
 
     else:
         # Close the sequences
@@ -185,7 +186,8 @@ def post_process(seq_tuple):
             list_job_id = merge_dl1_datacheck(seq_list)
             longterm_job_id = daily_datacheck(daily_longterm_cmd(list_job_id))
             cherenkov_job_id = cherenkov_transparency(cherenkov_transparency_cmd(longterm_job_id))
-            create_longterm_symlink(cherenkov_job_id)
+            if cfg.getboolean("lstchain", "create_longterm_symlink"):
+                create_longterm_symlink(cherenkov_job_id)
 
         time.sleep(600)
 


### PR DESCRIPTION
This is necessary for autocloser to work for dates that are processed with prod_ids that are not vX.Y.Z, such as tests like "v0.11_test". In this case, the longterm symlink should not be created and if "create_longterm_symlink" is set to True autocloser will fail because the prod_id doesn't follow the pattern vX.Y.Z. 