### PR TITLE
Add RAW_R0_DIR parameter to sequencer.cfg 

### DIFF
--- a/src/osa/configs/sequencer.cfg
+++ b/src/osa/configs/sequencer.cfg
@@ -9,7 +9,8 @@
 BASE: test_osa/test_files0
 # The directories below can be left untouched.
 MONITORING: %(BASE)s/monitoring
-R0_DIR: %(BASE)s/R0
+R0_DIR: %(BASE)s/R0G
+RAW_R0_DIR: %(BASE)s/R0
 DRIVE_DIR: %(MONITORING)s/DrivePositioning
 RUN_SUMMARY_DIR: %(MONITORING)s/RunSummary
 RUN_CATALOG: %(MONITORING)s/RunCatalog

--- a/src/osa/conftest.py
+++ b/src/osa/conftest.py
@@ -147,6 +147,13 @@ def r0_dir(base_test_dir):
 
 
 @pytest.fixture(scope="session")
+def r0g_dir(base_test_dir):
+    r0_directory = base_test_dir / "R0G" / nightdir
+    r0_directory.mkdir(parents=True, exist_ok=True)
+    return r0_directory
+
+
+@pytest.fixture(scope="session")
 def r0_data(r0_dir):
     r0_files = []
     for i in range(4, 8):
@@ -154,6 +161,16 @@ def r0_data(r0_dir):
         r0_file.touch()
         r0_files.append(r0_file)
     return r0_files
+
+
+@pytest.fixture(scope="session")
+def r0g_data(r0g_dir):
+    r0g_files = []
+    for i in range(4, 8):
+        r0g_file = r0g_dir / f"LST-1.1.Run0180{i}.0000.fits.fz"
+        r0g_file.touch()
+        r0g_files.append(r0g_file)
+    return r0g_files
 
 
 @pytest.fixture(scope="session")

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -358,7 +358,7 @@ def is_run_already_copied(date: datetime, run_id: int) -> bool:
     r0_dir = Path(cfg.get("LST1", "RAW_R0_DIR"))
     r0g_dir = Path(cfg.get("LST1", "R0_DIR"))
     r0_files = glob.glob(f"{r0_dir}/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
-    r0_files = glob.glob(f"{r0g_dir}/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
+    r0g_files = glob.glob(f"{r0g_dir}/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
     return len(r0_files)==len(r0g_files)
 
 
@@ -465,10 +465,10 @@ def check_failed_jobs(date: datetime):
     missing_runs = []
 
     date_str = date_to_dir(date)
-    r0_dir = Path(cfg.get("LST1", "RAW_R0_DIR"))
-    r0g_dir = Path(cfg.get("LST1", "R0_DIR"))
-    r0_files = glob.glob(f"{r0_dir}/{date_str}/LST-1.?.Run?????.????.fits.fz")
-    r0g_files = glob.glob(f"{r0g_dir}/{date_str}/LST-1.?.Run?????.????.fits.fz")
+    r0_dir = Path(cfg.get("LST1", "RAW_R0_DIR")) / date_str
+    r0g_dir = Path(cfg.get("LST1", "R0_DIR")) / date_str
+    r0_files = glob.glob(f"{r0_dir}/LST-1.?.Run?????.????.fits.fz")
+    r0g_files = glob.glob(f"{r0g_dir}/LST-1.?.Run?????.????.fits.fz")
     all_r0_runs = [parse_r0_filename(i).run for i in r0_files]
     all_r0g_runs = [parse_r0_filename(i).run for i in r0g_files]
 
@@ -479,17 +479,15 @@ def check_failed_jobs(date: datetime):
 
     missing_runs.sort()
     if missing_runs:
-        output_dir = base_dir / f"R0G/{date_str}/"
         log.info(
             f"Some runs are missing. Copying R0 files of runs {pd.Series(missing_runs).unique()} "
-            f"directly to {output_dir}"
+            f"directly to {r0g_dir}"
         )
 
         for run in missing_runs:
-            
-            files = base_dir.glob(f"R0/{date_str}/LST-1.?.Run{run:05d}.????.fits.fz")
+            files = r0_dir.glob(f"LST-1.?.Run{run:05d}.????.fits.fz")
             for file in files:
-                sp.run(["cp", file, output_dir])
+                sp.run(["cp", file, r0g_dir])
 
     GainSel_dir = Path(cfg.get("LST1", "GAIN_SELECTION_FLAG_DIR"))
     flagfile_dir = GainSel_dir / date_str

--- a/src/osa/scripts/gain_selection.py
+++ b/src/osa/scripts/gain_selection.py
@@ -276,11 +276,10 @@ def apply_gain_selection(date: datetime, start: int, end: int, tool: str = None,
     data_runs = summary_table[summary_table["run_type"] == "DATA"]
     log.info(f"Found {len(data_runs)} DATA runs to which apply the gain selection")
 
-    base_dir = Path(cfg.get("LST1", "BASE"))
     date_str = date_to_dir(date)
-    r0_dir = base_dir / "R0" / date_str
-    output_dir = base_dir / f"R0G/{date_str}"
-    log_dir = base_dir / f"R0G/log/{date_str}"
+    r0_dir = Path(cfg.get("LST1", "RAW_R0_DIR")) / date_str
+    output_dir = Path(cfg.get("LST1", "R0_DIR")) / date_str
+    log_dir = Path(cfg.get("LST1", "R0_DIR")) / f"log/{date_str}"
     if not simulate:
         output_dir.mkdir(parents=True, exist_ok=True)
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -356,9 +355,10 @@ def update_history_file(run_id: str, subrun: str, log_dir: Path, history_file: P
 
 def is_run_already_copied(date: datetime, run_id: int) -> bool:
     """Check if the R0 files of a given run have already been copied to the R0G directory."""
-    base_dir = Path(cfg.get("LST1", "BASE"))
-    r0_files = glob.glob(f"{base_dir}/R0/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
-    r0g_files = glob.glob(f"{base_dir}/R0G/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
+    r0_dir = Path(cfg.get("LST1", "RAW_R0_DIR"))
+    r0g_dir = Path(cfg.get("LST1", "R0_DIR"))
+    r0_files = glob.glob(f"{r0_dir}/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
+    r0_files = glob.glob(f"{r0g_dir}/{date_to_dir(date)}/LST-1.?.Run{run_id:05d}.????.fits.fz")
     return len(r0_files)==len(r0g_files)
 
 
@@ -465,9 +465,10 @@ def check_failed_jobs(date: datetime):
     missing_runs = []
 
     date_str = date_to_dir(date)
-    base_dir = Path(cfg.get("LST1", "BASE"))
-    r0_files = glob.glob(f"{base_dir}/R0/{date_str}/LST-1.?.Run?????.????.fits.fz")
-    r0g_files = glob.glob(f"{base_dir}/R0G/{date_str}/LST-1.?.Run?????.????.fits.fz")
+    r0_dir = Path(cfg.get("LST1", "RAW_R0_DIR"))
+    r0g_dir = Path(cfg.get("LST1", "R0_DIR"))
+    r0_files = glob.glob(f"{r0_dir}/{date_str}/LST-1.?.Run?????.????.fits.fz")
+    r0g_files = glob.glob(f"{r0g_dir}/{date_str}/LST-1.?.Run?????.????.fits.fz")
     all_r0_runs = [parse_r0_filename(i).run for i in r0_files]
     all_r0g_runs = [parse_r0_filename(i).run for i in r0g_files]
 

--- a/src/osa/scripts/tests/test_osa_scripts.py
+++ b/src/osa/scripts/tests/test_osa_scripts.py
@@ -189,7 +189,8 @@ def test_autocloser(running_analysis_dir):
 
 
 def test_closer(
-    r0_data,
+    r0g_data,
+    run_catalog,
     running_analysis_dir,
     test_observed_data,
     run_summary_file,
@@ -210,7 +211,7 @@ def test_closer(
     if night_finished_flag.exists():
         night_finished_flag.unlink()
 
-    for r0_file in r0_data:
+    for r0_file in r0g_data:
         assert r0_file.exists()
     for file in drs4_time_calibration_files:
         assert file.exists()

--- a/src/osa/scripts/tests/test_osa_scripts.py
+++ b/src/osa/scripts/tests/test_osa_scripts.py
@@ -340,7 +340,7 @@ def test_drs4_pedestal_cmd(base_test_dir):
     from osa.scripts.calibration_pipeline import drs4_pedestal_command
 
     cmd = drs4_pedestal_command(drs4_pedestal_run_id="01804")
-    r0_dir = base_test_dir / "R0"
+    r0_dir = base_test_dir / "R0G"
     expected_command = [
         cfg.get("lstchain", "drs4_baseline"),
         "-r",
@@ -359,7 +359,7 @@ def test_calibration_file_cmd(base_test_dir):
     from osa.scripts.calibration_pipeline import calibration_file_command
 
     cmd = calibration_file_command(drs4_pedestal_run_id="01804", pedcal_run_id="01809")
-    r0_dir = base_test_dir / "R0"
+    r0_dir = base_test_dir / "R0G"
     expected_command = [
         cfg.get("lstchain", "charge_calibration"),
         "-p",

--- a/src/osa/tests/test_raw.py
+++ b/src/osa/tests/test_raw.py
@@ -17,7 +17,7 @@ def test_get_raw_dir():
     assert get_raw_dir(options.date) == r0_dir
 
 
-def test_get_check_raw_dir(r0_dir):
+def test_get_check_raw_dir(r0g_dir):
     options.date = datetime.fromisoformat("2020-01-18")
     from osa.raw import get_check_raw_dir
 
@@ -26,13 +26,13 @@ def test_get_check_raw_dir(r0_dir):
 
     options.date = datetime.fromisoformat("2020-01-17")
     raw_dir = get_check_raw_dir(options.date)
-    assert raw_dir.resolve() == r0_dir
+    assert raw_dir.resolve() == r0g_dir
 
 
-def test_is_raw_data_available(r0_data):
+def test_is_raw_data_available(r0g_data):
     from osa.raw import is_raw_data_available
 
-    for file in r0_data:
+    for file in r0g_data:
         assert file.exists()
 
     options.date = datetime.fromisoformat("2020-01-17")

--- a/src/osa/veto.py
+++ b/src/osa/veto.py
@@ -81,7 +81,7 @@ def set_closed_sequence(sequence):
 def get_closed_list(sequence_list) -> list:
     """Get the list of closed sequences."""
     analysis_dir = Path(options.directory)
-    closed_ls = analysis_dir.glob("*.closed")
+    closed_ls = analysis_dir.glob("sequence_*.closed")
     closed_list = []
     for file in closed_ls:
         # Extract the job name: LST1_XXXXX


### PR DESCRIPTION
RAW_R0_DIR would be used to specify the path of the original R0 files, while R0_DIR would be used to specify the path in which the R0G files should be produced, and the path from which sequencer should read the R0 files (either R0, R0G or R0V)