### PR TITLE
Allow to use a name different from tailcutXY as dl1_prod_id

### DIFF
--- a/src/osa/configs/sequencer.cfg
+++ b/src/osa/configs/sequencer.cfg
@@ -44,6 +44,7 @@ PROD_ID: v0.1.0
 # Change this to produce a different DL1b or DL2 sub-productions.
 # Otherwise, keep it empty to use the common PROD-ID
 DL1_PROD_ID: tailcut84
+DL1_PROD_ID_PREFIX: tailcut
 DL2_PROD_ID: model2
 
 [lstchain]

--- a/src/osa/paths.py
+++ b/src/osa/paths.py
@@ -433,11 +433,12 @@ def get_dl1_prod_id(config_filename):
         
     picture_thresh = data["tailcuts_clean_with_pedestal_threshold"]["picture_thresh"]
     boundary_thresh = data["tailcuts_clean_with_pedestal_threshold"]["boundary_thresh"]
+    dl1_prod_id_prefix = cfg.get("LST1", "DL1_PROD_ID_PREFIX")
 
     if boundary_thresh == 4:
-        return f"tailcut{picture_thresh}{boundary_thresh}"
+        return f"{dl1_prod_id_prefix}{picture_thresh}{boundary_thresh}"
     else:
-        return f"tailcut{picture_thresh}{boundary_thresh:02d}"
+        return f"{dl1_prod_id_prefix}{picture_thresh}{boundary_thresh:02d}"
 
 
 def get_dl2_nsb_prod_id(rf_model: Path) -> str:


### PR DESCRIPTION
This is necessary for example to process runs without the Cat-B calibration, which should have a different prod id name (such as "noCatB_tailcutXY") so that they can be distinguished.