### PR TITLE
 CatB/Tailcuts pilot script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ gain_selection = "osa.scripts.gain_selection:main"
 update_source_catalog = "osa.scripts.update_source_catalog:main"
 gainsel_webmaker = "osa.scripts.gainsel_webmaker:main"
 sequencer_catB_tailcuts = "osa.scripts.sequencer_catB_tailcuts:main"
+catb_tailcuts_pipeline = "osa.scripts.catb_tailcuts_pipeline:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/osa/catb_utils.py
+++ b/src/osa/catb_utils.py
@@ -1,0 +1,115 @@
+import logging
+import re
+from pathlib import Path
+
+from osa.configs import options
+from osa.configs.config import cfg
+from osa.utils.logging import myLogger
+
+log = myLogger(logging.getLogger(__name__))
+
+
+BASE_SERVICE = Path(
+    "/fefs/onsite/data/lst-pipe/LSTN-01/service/PixelCalibration/Cat-A"
+)
+
+
+def load_calibration_table() -> str:
+    table_file = Path(cfg.get(options.tel_id, "TABLE_CATB"))
+
+    if not table_file.exists():
+        raise FileNotFoundError(f"Cat-B calibration table not found: {table_file}")
+
+    log.info(f"Using Cat-B calibration table: {table_file}")
+
+    return table_file.read_text()
+
+
+def parse_calibration_table(table_text: str) -> list[dict]:
+    periods: list[dict] = []
+
+    for line in table_text.splitlines():
+
+        if "since" not in line:
+            continue
+
+        match = re.search(r"since\s+(\d{8})\s+\(r(\d+)\)", line)
+        if not match:
+            continue
+
+        since_run = int(match.group(2))
+
+        calib_matches = re.findall(r"(\d{8})\s+\(r(\d+)\)", line)
+
+        if len(calib_matches) < 3:
+            continue
+
+        calib_date, calibration_run = calib_matches[1]
+        ffactor_date, ffactor_run = calib_matches[-2]
+
+        periods.append(
+            {
+                "since_run": since_run,
+                "calib_date": calib_date,
+                "calibration_run": int(calibration_run),
+                "ffactor_date": ffactor_date,
+                "ffactor_run": int(ffactor_run),
+            }
+        )
+
+    return sorted(periods, key=lambda x: x["since_run"], reverse=True)
+
+
+def find_period_for_run(run_id: int, periods: list[dict]) -> dict:
+
+    for period in periods:
+        if run_id >= period["since_run"]:
+            return period
+
+    log.warning(
+        f"Run {run_id} prior to the first period in calibration table, using fallback"
+    )
+
+    return periods[-1]
+
+
+def find_catA_file(calib_date: str, calibration_run: int) -> str:
+
+    path = BASE_SERVICE / "calibration" / calib_date / "pro"
+
+    files = list(path.glob(f"*Run{calibration_run:05d}*.fits*"))
+
+    if not files:
+        raise RuntimeError(f"No Cat-A file for run {calibration_run} in {path}")
+
+    return str(sorted(files)[0])
+
+
+def find_systematics_file(calib_date: str) -> str:
+
+    path = BASE_SERVICE / "ffactor_systematics" / calib_date / "v0.3.1"
+
+    files = list(path.glob("scan_fit*.h5"))
+
+    if not files:
+        raise RuntimeError(f"No systematics for date {calib_date} in {path}")
+
+    return str(sorted(files)[0])
+
+
+def get_catA_and_systematics(run_id: int) -> tuple[str, str]:
+
+    table_text = load_calibration_table()
+
+    periods = parse_calibration_table(table_text)
+
+    period = find_period_for_run(run_id, periods)
+
+    calib_date = period["calib_date"]
+    calibration_run = period["calibration_run"]
+    ffactor_date = period["ffactor_date"]
+
+    catA_file = find_catA_file(calib_date, calibration_run)
+    systematics_file = find_systematics_file(ffactor_date)
+
+    return catA_file, systematics_file

--- a/src/osa/catb_utils.py
+++ b/src/osa/catb_utils.py
@@ -86,7 +86,7 @@ def find_catA_file(calib_date: str, calibration_run: int) -> str:
     if not files:
         raise RuntimeError(f"No Cat-A file for run {calibration_run} in {path}")
 
-    return str(files[0]))
+    return str(files[0])
 
 
 def find_systematics_file(calib_date: str) -> str:

--- a/src/osa/catb_utils.py
+++ b/src/osa/catb_utils.py
@@ -15,8 +15,11 @@ BASE_SERVICE = Path(
 
 
 def load_calibration_table() -> str:
+    if not cfg.has_option(options.tel_id, "TABLE_CATB"):
+        raise RuntimeError(
+            f"Missing TABLE_CATB option in [{options.tel_id}] config section"
+        )
     table_file = Path(cfg.get(options.tel_id, "TABLE_CATB"))
-
     if not table_file.exists():
         raise FileNotFoundError(f"Cat-B calibration table not found: {table_file}")
 
@@ -74,27 +77,30 @@ def find_period_for_run(run_id: int, periods: list[dict]) -> dict:
 
 
 def find_catA_file(calib_date: str, calibration_run: int) -> str:
-
-    path = BASE_SERVICE / "calibration" / calib_date / "pro"
-
-    files = list(path.glob(f"*Run{calibration_run:05d}*.fits*"))
+    base_service = Path(
+        cfg.get(options.tel_id, "CAT_A_CALIB_BASE", fallback=str(BASE_SERVICE))
+    )
+    path = base_service / "calibration" / calib_date / "pro"
+    files = sorted(path.glob(f"*Run{calibration_run:05d}*.fits*"))
 
     if not files:
         raise RuntimeError(f"No Cat-A file for run {calibration_run} in {path}")
 
-    return str(sorted(files)[0])
+    return str(files[0]))
 
 
 def find_systematics_file(calib_date: str) -> str:
 
-    path = BASE_SERVICE / "ffactor_systematics" / calib_date / "v0.3.1"
+    base_service = Path(
+        cfg.get(options.tel_id, "CAT_A_CALIB_BASE", fallback=str(BASE_SERVICE))
+    )
+    base_dir = base_service / "ffactor_systematics" / calib_date
 
-    files = list(path.glob("scan_fit*.h5"))
+    files = sorted(base_dir.rglob("*.h5"))
 
     if not files:
-        raise RuntimeError(f"No systematics for date {calib_date} in {path}")
-
-    return str(sorted(files)[0])
+        raise RuntimeError(f"No systematics for date {calib_date} in {base_dir}")
+    return str(files[0])
 
 
 def get_catA_and_systematics(run_id: int) -> tuple[str, str]:
@@ -102,6 +108,10 @@ def get_catA_and_systematics(run_id: int) -> tuple[str, str]:
     table_text = load_calibration_table()
 
     periods = parse_calibration_table(table_text)
+    if not periods:
+        raise ValueError(
+            "No valid calibration periods found in Cat-B calibration table"
+        )
 
     period = find_period_for_run(run_id, periods)
 

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -242,7 +242,6 @@ def parse_args() -> argparse.Namespace:
             "ST",
             "LST1",
             "LST2",
-            "all",
         ],
     )
 

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -11,6 +11,7 @@ import logging
 import subprocess as sp
 import sys
 from pathlib import Path
+from datetime import datetime
 
 from osa.configs import options
 from osa.configs.config import cfg
@@ -248,6 +249,37 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
+def _write_history(
+    run_id: int,
+    exit_code: int,
+) -> None:
+
+    history_file = (
+        Path(options.directory)
+        / (
+            f"{options.tel_id}_catB_tailcuts_"
+            f"{run_id:05d}.history"
+        )
+    )
+
+    timestamp = datetime.now().strftime(
+        "%Y-%m-%d %H:%M"
+    )
+
+    version = get_major_version(
+        get_lstchain_version()
+    )
+
+    with open(history_file, "a") as history:
+
+        history.write(
+            f"{run_id:05d} "
+            f"catb_tailcuts_pipeline "
+            f"{version} "
+            f"{timestamp} "
+            f"{exit_code}\n"
+        )
+
 
 def main() -> int:
 
@@ -329,6 +361,7 @@ def main() -> int:
                 rc = sp.run(cmd).returncode
 
                 if rc != 0:
+                    _write_history(run_id, rc)
                     return rc
 
     #
@@ -374,12 +407,14 @@ def main() -> int:
                 rc = sp.run(cmd).returncode
 
                 if rc != 0:
+                    _write_history(run_id, rc)
                     return rc
 
     #
     # Everything finished successfully
     #
     if not options.simulate:
+        _write_history(run_id, 0)
 
         catb_closed_file.touch()
 

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -1,4 +1,5 @@
-"""Worker script to run CatB calibration and tailcuts finder for a single run.
+"""
+Worker script to run CatB calibration and tailcuts finder for a single run.
 
 This is analogous to datasequence.py, but run-wise and without any SLURM
 submission inside. It is meant to be executed from a pilot script submitted

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -1,0 +1,396 @@
+"""
+Worker script to run CatB calibration and tailcuts finder for a single run.
+
+This is analogous to datasequence.py, but run-wise and without any SLURM
+submission inside. It is meant to be executed from a pilot script submitted
+with sbatch by sequencer_catB_tailcuts.py.
+"""
+
+import argparse
+import logging
+import subprocess as sp
+import sys
+from pathlib import Path
+
+from osa.configs import options
+from osa.configs.config import cfg
+from osa.nightsummary.extract import get_last_pedcalib
+from osa.paths import (
+    analysis_path,
+    catB_calibration_file_exists,
+    get_major_version,
+)
+from osa.utils.cliopts import valid_date
+from osa.utils.logging import myLogger
+from osa.utils.utils import (
+    get_calib_filters,
+    get_lstchain_version,
+)
+
+from osa.utils.utils import date_to_iso
+
+# TODO:
+# Import from common module instead of sequencer_catB_tailcuts
+from osa.catb_utils import (
+    get_catA_and_systematics,
+)
+
+log = myLogger(logging.getLogger(__name__))
+
+
+def _catb_command_args(run_id: int) -> list[str]:
+
+    command = cfg.get(
+        "lstchain",
+        "catB_calibration",
+    )
+
+    if cfg.getboolean(
+        "lstchain",
+        "use_lstcam_env_for_CatB_calib",
+    ):
+        base_cmd = (
+            ["conda", "run", "-n", "lstcam-env"]
+            + command.split()
+        )
+    else:
+        base_cmd = command.split()
+
+    filters = get_calib_filters(run_id)
+
+    base_dir = Path(
+        cfg.get(options.tel_id, "BASE")
+    ).resolve()
+
+    r0_dir = Path(
+        cfg.get(options.tel_id, "R0_DIR")
+    ).resolve()
+
+    lstchain_version = get_major_version(
+        get_lstchain_version()
+    )
+
+    analysis_dir = cfg.get(
+        options.tel_id,
+        "ANALYSIS_DIR",
+    )
+
+    args = base_cmd + [
+        "-r",
+        f"{run_id:05d}",
+        "-b",
+        str(base_dir),
+        f"--r0-dir={r0_dir}",
+        f"--filters={filters}",
+    ]
+
+    if options.input_state == "catA_calibrated":
+
+        catA_file, systematics_file = (
+            get_catA_and_systematics(run_id)
+        )
+
+        log.info(
+            f"[CatB] Using Cat-A file: {catA_file}"
+        )
+
+        log.info(
+            f"[CatB] Using systematics: "
+            f"{systematics_file}"
+        )
+
+        args.extend(
+            [
+                f"--cat_A_calibration_file={catA_file}",
+                f"--systematics_file={systematics_file}",
+            ]
+        )
+
+    else:
+
+        catA_calib_run = get_last_pedcalib(
+            options.date
+        )
+
+        args.append(
+            f"--catA_calibration_run={catA_calib_run}"
+        )
+
+    if command == "onsite_create_cat_B_calibration_file":
+
+        args.append(
+            f"--interleaved-dir={analysis_dir}"
+        )
+
+    elif (
+        command
+        == "lstcam_calib_onsite_create_cat_B_calibration_file"
+    ):
+
+        args.append(
+            f"--dl1-dir={analysis_dir}"
+        )
+
+        args.append(
+            f"--lstchain-version={lstchain_version[1:]}"
+        )
+
+    if options.overwrite_catB:
+        args.append("--yes")
+
+    return args
+
+
+def _tailcuts_command_args(
+    run_id: int,
+) -> list[str]:
+
+    command = cfg.get(
+        "lstchain",
+        "tailcuts_finder",
+    )
+
+    input_dir = Path(options.directory)
+
+    output_dir = Path(
+        cfg.get(
+            options.tel_id,
+            "TAILCUTS_FINDER_DIR",
+        )
+    )
+
+    return command.split() + [
+        f"--input-dir={input_dir}",
+        f"--run={run_id}",
+        f"--output-dir={output_dir}",
+    ]
+
+
+def _tailcuts_config_file(
+    run_id: int,
+) -> Path:
+
+    return (
+        Path(
+            cfg.get(
+                options.tel_id,
+                "TAILCUTS_FINDER_DIR",
+            )
+        )
+        / f"dl1ab_Run{run_id:05d}.json"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+
+    p = argparse.ArgumentParser()
+
+    p.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+    )
+
+    p.add_argument(
+        "--date",
+        required=True,
+        type=valid_date,
+        help="Night in YYYY-MM-DD format",
+    )
+
+    p.add_argument(
+        "--input-state",
+        choices=[
+            "legacy_raw",
+            "gain_selected",
+            "catA_calibrated",
+        ],
+        default="legacy_raw",
+    )
+
+    p.add_argument(
+        "--overwrite-catB",
+        action="store_true",
+        default=False,
+    )
+
+    p.add_argument(
+        "--overwrite-tailcuts",
+        action="store_true",
+        default=False,
+    )
+
+    p.add_argument(
+        "--simulate",
+        action="store_true",
+        default=False,
+    )
+
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        default=False,
+    )
+
+    p.add_argument(
+        "run_id",
+        type=int,
+    )
+
+    p.add_argument(
+        "tel_id",
+        choices=[
+            "ST",
+            "LST1",
+            "LST2",
+            "all",
+        ],
+    )
+
+    return p.parse_args()
+
+
+
+def main() -> int:
+
+    args = parse_args()
+
+    options.tel_id = args.tel_id
+    options.simulate = args.simulate
+
+    options.overwrite_catB = (
+        args.overwrite_catB
+    )
+
+    options.overwrite_tailcuts = (
+        args.overwrite_tailcuts
+    )
+
+    options.input_state = (
+        args.input_state
+    )
+
+    if args.config is not None:
+        options.configfile = (
+            args.config.resolve()
+        )
+    else:
+        options.configfile = None
+
+    options.date = args.date
+
+    options.directory = analysis_path(
+        options.tel_id
+    )
+
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
+
+    run_id = args.run_id
+
+    catb_closed_file = (
+        Path(options.directory)
+        / f"catB_{run_id:05d}.closed"
+    )
+
+    #
+    # CatB calibration
+    #
+    if cfg.getboolean(
+        "lstchain",
+        "apply_catB_calibration",
+    ):
+
+        if (
+            catB_calibration_file_exists(run_id)
+            and not options.overwrite_catB
+        ):
+
+            log.info(
+                f"CatB calibration already exists "
+                f"for run {run_id:05d}"
+            )
+
+        else:
+
+            cmd = _catb_command_args(run_id)
+
+            log.info(
+                f"Running CatB calibration "
+                f"for run {run_id:05d}"
+            )
+
+            log.debug(
+                f"Command: {' '.join(cmd)}"
+            )
+
+            if not options.simulate:
+
+                rc = sp.run(cmd).returncode
+
+                if rc != 0:
+                    return rc
+
+    #
+    # Tailcuts finder
+    #
+    if not cfg.getboolean(
+        "lstchain",
+        "apply_standard_dl1b_config",
+    ):
+
+        cfg_file = _tailcuts_config_file(
+            run_id
+        )
+
+        if (
+            cfg_file.exists()
+            and not options.overwrite_tailcuts
+        ):
+
+            log.info(
+                f"Tailcuts config already exists "
+                f"for run {run_id:05d}: "
+                f"{cfg_file.name}"
+            )
+
+        else:
+
+            cmd = _tailcuts_command_args(
+                run_id
+            )
+
+            log.info(
+                f"Running tailcuts finder "
+                f"for run {run_id:05d}"
+            )
+
+            log.debug(
+                f"Command: {' '.join(cmd)}"
+            )
+
+            if not options.simulate:
+
+                rc = sp.run(cmd).returncode
+
+                if rc != 0:
+                    return rc
+
+    #
+    # Everything finished successfully
+    #
+    if not options.simulate:
+
+        catb_closed_file.touch()
+
+        log.info(
+            f"Created {catb_closed_file.name}"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -1,5 +1,4 @@
-"""
-Worker script to run CatB calibration and tailcuts finder for a single run.
+"""Worker script to run CatB calibration and tailcuts finder for a single run.
 
 This is analogous to datasequence.py, but run-wise and without any SLURM
 submission inside. It is meant to be executed from a pilot script submitted
@@ -26,8 +25,6 @@ from osa.utils.utils import (
     get_calib_filters,
     get_lstchain_version,
 )
-
-from osa.utils.utils import date_to_iso
 
 # TODO:
 # Import from common module instead of sequencer_catB_tailcuts

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -255,10 +255,7 @@ def _write_history(
 
     history_file = (
         Path(options.directory)
-        / (
-            f"{options.tel_id}_catB_tailcuts_"
-            f"{run_id:05d}.history"
-        )
+        / f"{options.tel_id}_{run_id:05d}.history"
     )
 
     timestamp = datetime.now().strftime(
@@ -276,9 +273,10 @@ def _write_history(
             f"catb_tailcuts_pipeline "
             f"{version} "
             f"{timestamp} "
+            f"None "
+            f"None "
             f"{exit_code}\n"
         )
-
 
 def main() -> int:
 

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Worker script to run CatB calibration and tailcuts finder for a single run.
 
 This is analogous to datasequence.py, but run-wise and without any SLURM

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -238,7 +238,6 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "tel_id",
         choices=[
-            "ST",
             "LST1",
             "LST2",
         ],

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -1,6 +1,4 @@
-"""
-Worker script to run CatB calibration and tailcuts finder for a single run.
-
+""" Worker script to run CatB calibration and tailcuts finder for a single run.
 This is analogous to datasequence.py, but run-wise and without any SLURM
 submission inside. It is meant to be executed from a pilot script submitted
 with sbatch by sequencer_catB_tailcuts.py.

--- a/src/osa/scripts/catb_tailcuts_pipeline.py
+++ b/src/osa/scripts/catb_tailcuts_pipeline.py
@@ -1,9 +1,10 @@
-""" Worker script to run CatB calibration and tailcuts finder for a single run.
+""" 
+Worker script to run CatB calibration and tailcuts finder for a single run.
+
 This is analogous to datasequence.py, but run-wise and without any SLURM
 submission inside. It is meant to be executed from a pilot script submitted
 with sbatch by sequencer_catB_tailcuts.py.
 """
-
 import argparse
 import logging
 import subprocess as sp

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from astropy.table import Table
 import subprocess as sp
+from datetime import datetime
 
 from osa.configs import options
 from osa.configs.config import cfg
@@ -87,7 +88,26 @@ def create_run_history_file(run_id: int) -> Path:
         / f"{options.tel_id}_{run_id:05d}.history"
     )
 
-    history_file.touch(exist_ok=True)
+    if history_file.exists():
+        return history_file
+
+    version = get_major_version(
+        get_lstchain_version()
+    )
+
+    timestamp = datetime.now().strftime(
+        "%Y-%m-%d %H:%M"
+    )
+
+    history_file.write_text(
+        f"{run_id:05d} "
+        f"lstchain_data_r0_to_dl1 "
+        f"{version} "
+        f"{timestamp} "
+        f"None "
+        f"all_subruns_finished "
+        f"0\n"
+    )
 
     return history_file
 

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -1,6 +1,6 @@
 import glob
 import re
-import argparse
+from argparse import ArgumentParser
 import logging
 from pathlib import Path
 from astropy.table import Table
@@ -9,10 +9,11 @@ import subprocess as sp
 from osa.configs import options
 from osa.configs.config import cfg
 from osa.nightsummary.extract import get_last_pedcalib
-from osa.utils.cliopts import valid_date, set_default_date_if_needed
+from osa.utils.cliopts import common_parser, set_default_date_if_needed
 from osa.utils.logging import myLogger
 from osa.job import run_sacct, get_sacct_output
 from osa.utils.utils import date_to_dir, get_calib_filters, get_lstchain_version
+from osa.utils.utils import date_to_iso
 from osa.paths import (
     catB_closed_file_exists,
     catB_calibration_file_exists,
@@ -22,39 +23,18 @@ from osa.paths import (
 
 log = myLogger(logging.getLogger())
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "-c",                                                                                            
-    "--config",                                                                                      
-    action="store",
-    type=Path,
-    help="Configuration file",
-)
-parser.add_argument(                                                                                     
-    "-d",                                                                                            
-    "--date",
-    type=valid_date,
-    default=None,
-)
-parser.add_argument(
-    "-v",                                                                                      
-    "--verbose",
-    action="store_true",
-    default=False,
-    help="Activate debugging mode.",
-)
-parser.add_argument(
-    "-s",
-    "--simulate",
-    action="store_true",
-    default=False,
-    help="Simulate launching of the sequencer_catB_tailcuts script.",
-)
+parser = ArgumentParser(parents=[common_parser])
 parser.add_argument(
     "--overwrite-tailcuts",
     action="store_true",
     default=False,
     help="Overwrite the tailcuts config file if it already exists.",
+)
+parser.add_argument(
+    "--input-state",
+    choices=["legacy_raw", "gain_selected", "catA_calibrated"],
+    default="legacy_raw",
+    help="Declared preprocessing state of input data",
 )
 parser.add_argument(
     "--overwrite-catB",
@@ -100,139 +80,204 @@ def r0_to_dl1_step_finished_for_run(run_id: int) -> bool:
     return True
 
 
-def get_catB_last_job_id(run_id: int) -> int:
-    """Get job id of the last Cat-B calibration job that was launched for a given run."""
-    log_dir = Path(options.directory) / "log"
-    filenames = glob.glob(f"{log_dir}/catB_calibration_{run_id:05d}_*.err")
-    if filenames:
-        match = re.search(f"catB_calibration_{run_id:05d}_(\d+).err", sorted(filenames)[-1])
-        job_id = match.group(1)
-        return job_id
-
-
-def launch_catB_calibration(run_id: int):
-    """
-    Launch the Cat-B calibration script for a given run if the Cat-B calibration 
-    file has not been created yet. If the Cat-B calibration script was launched
-    before and it finished successfully, it creates a catB_{run}.closed file.
-    """
-    job_id = get_catB_last_job_id(run_id)
-    if job_id and not options.overwrite_catB:
-        job_status = get_sacct_output(run_sacct(job_id=job_id))["State"]
-        if job_status.item() in ["RUNNING", "PENDING"]:
-            log.debug(f"Job {job_id} (corresponding to run {run_id:05d}) is still running.")
-
-        elif job_status.item() == "COMPLETED":
-            catB_closed_file = Path(options.directory) / f"catB_{run_id:05d}.closed"
-            catB_closed_file.touch()
-            log.debug(
-                f"Cat-B job {job_id} (corresponding to run {run_id:05d}) finished "
-                f"successfully. Creating file {catB_closed_file}"
-            )
-
-        else: 
-            log.warning(f"Cat-B job {job_id} (corresponding to run {run_id:05d}) failed.")
-
-    else:
-        if catB_calibration_file_exists(run_id):
-            if not options.overwrite_catB:
-                log.info(f"Cat-B calibration file already produced for run {run_id:05d}.")
-                return 
-            else:
-                log.info(f"Cat-B calibration file already produced for run {run_id:05d}. Overwriting it.")
-
-        command = cfg.get("lstchain", "catB_calibration")
-        if cfg.getboolean("lstchain", "use_lstcam_env_for_CatB_calib"):
-            env_command = f"conda run -n lstcam-env {command}"
-        else:
-            env_command = command
-        options.filters = get_calib_filters(run_id) 
-        base_dir = Path(cfg.get(options.tel_id, "BASE")).resolve()
-        r0_dir = Path(cfg.get(options.tel_id, "R0_DIR")).resolve()
-        log_dir = Path(options.directory) / "log"
-        catA_calib_run = get_last_pedcalib(options.date)
-        slurm_account = cfg.get("SLURM", "ACCOUNT")
-        lstchain_version = get_major_version(get_lstchain_version())
-        analysis_dir = cfg.get("LST1", "ANALYSIS_DIR")
-        cmd = ["sbatch", f"--account={slurm_account}", "--parsable",
-            "-o", f"{log_dir}/catB_calibration_{run_id:05d}_%j.out",
-            "-e", f"{log_dir}/catB_calibration_{run_id:05d}_%j.err",
-            env_command,
-            f"-r {run_id:05d}",
-            f"--catA_calibration_run={catA_calib_run}",
-            "-b", base_dir,
-            f"--r0-dir={r0_dir}",
-            f"--filters={options.filters}",
-        ]
-        
-        if command=="onsite_create_cat_B_calibration_file":
-            cmd.append(f"--interleaved-dir={analysis_dir}")
-        elif command=="lstcam_calib_onsite_create_cat_B_calibration_file":
-            cmd.append(f"--dl1-dir={analysis_dir}")
-            cmd.append(f"--lstchain-version={lstchain_version[1:]}")
-
-        if options.overwrite_catB:
-            cmd.append("--yes")
-
-        if not options.simulate:
-            job = sp.run(cmd, encoding="utf-8", capture_output=True, text=True, check=True)
-            job_id = job.stdout.strip()
-            log.debug(f"Launched Cat-B calibration job {job_id} for run {run_id}!")
-
-        else: 
-            log.info(f"Simulate launching of the {command} script.")
-            
-
-def launch_tailcuts_finder(run_id: int):
-    """
-    Launch the lstchain script to calculate the correct
-    tailcuts to use for a given run. 
-    """
-    command = cfg.get("lstchain", "tailcuts_finder")
-    slurm_account = cfg.get("SLURM", "ACCOUNT")
-    input_dir = Path(options.directory)
-    output_dir = Path(cfg.get(options.tel_id, "TAILCUTS_FINDER_DIR"))
-    log_dir = Path(options.directory) / "log"
-    log_file = log_dir / f"tailcuts_finder_{run_id:05d}_%j.log"
-    cmd = [
-        "sbatch", "--parsable",
-        f"--account={slurm_account}",
-        "-o", log_file,
-        command,
-        f"--input-dir={input_dir}",
-        f"--run={run_id}",
-        f"--output-dir={output_dir}",
-    ]
-    if not options.simulate:
-        job = sp.run(cmd, encoding="utf-8", capture_output=True, text=True, check=True)
-        job_id = job.stdout.strip()
-        log.debug(f"Launched lstchain_find_tailcuts job {job_id} for run {run_id}!")
-
-    else: 
-        log.info(f"Simulate launching of the {command} script.")
-
-
-
 def tailcuts_config_file_exists(run_id: int) -> bool:
     """Check if the config file created by the tailcuts finder script already exists."""
     tailcuts_config_file = Path(cfg.get(options.tel_id, "TAILCUTS_FINDER_DIR")) / f"dl1ab_Run{run_id:05d}.json"
     return tailcuts_config_file.exists()
+
+
+def write_pilot_script(run_id: int) -> Path:
+    """
+    Create a pilot script analogous to sequencer pilots.
+    """
+
+    log_dir = Path(options.directory) / "log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    job_name = (
+        f"{options.tel_id}_catB_tailcuts_{run_id:05d}"
+    )
+
+    account = cfg.get("SLURM", "ACCOUNT")
+
+    worker_argv = [
+        "catb_tailcuts_pipeline",
+        f"--date={date_to_iso(options.date)}",
+        f"--input-state={options.input_state}",
+    ]
+
+    if options.verbose:
+        worker_argv.append("--verbose")
+
+    if options.simulate:
+        worker_argv.append("--simulate")
+
+    if options.configfile:
+        worker_argv.extend(
+            [
+                "--config",
+                str(Path(options.configfile).resolve()),
+            ]
+        )
+
+    if options.overwrite_catB:
+        worker_argv.append("--overwrite-catB")
+
+    if options.overwrite_tailcuts:
+        worker_argv.append("--overwrite-tailcuts")
+
+    worker_argv.append(str(run_id))
+    worker_argv.append(options.tel_id)
+
+    content = ""
+    content += "#!/usr/bin/env python\n\n"
+
+    content += f"#SBATCH --job-name={job_name}\n"
+    content += f"#SBATCH --chdir={options.directory}\n"
+    content += (
+        f"#SBATCH --output=log/{job_name}_%j.out\n"
+    )
+    content += (
+        f"#SBATCH --error=log/{job_name}_%j.err\n"
+    )
+    content += (
+        f"#SBATCH --account={account}\n\n"
+    )
+    content += "#SBATCH --mem=12G\n\n"
+
+    content += "import subprocess\n"
+    content += "import sys\n\n"
+
+    content += "proc = subprocess.run([\n"
+
+    for arg in worker_argv:
+        content += f"    {arg!r},\n"
+
+    content += "])\n"
+    content += "sys.exit(proc.returncode)\n"
+
+    pilot_script = (
+        Path(options.directory)
+        / (
+            f"sequence_"
+            f"{options.tel_id}_"
+            f"{run_id:05d}_"
+            f"catb_tailcuts.py"
+        )
+    )
+
+    pilot_script.write_text(content)
+    pilot_script.chmod(0o755)
+
+    return pilot_script
+
+def submit_pilot_script(run_id: int) -> str | None:
+
+    pilot_script = write_pilot_script(run_id)
+
+    cmd = [
+        "sbatch",
+        "--parsable",
+        str(pilot_script),
+    ]
+
+    if options.simulate:
+
+        log.info(
+            f"Would submit {' '.join(cmd)}"
+        )
+
+        return None
+
+    job = sp.run(
+        cmd,
+        encoding="utf-8",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    job_id = job.stdout.strip()
+
+    log.info(
+        f"Submitted CatB pipeline for run "
+        f"{run_id:05d} ({job_id})"
+    )
+
+    return job_id
+
+
+def pilot_job_is_active(run_id: int) -> bool:
+
+    log_dir = Path(options.directory) / "log"
+
+    files = sorted(
+        glob.glob(
+            str(
+                log_dir
+                / (
+                    f"{options.tel_id}"
+                    f"_catB_tailcuts_"
+                    f"{run_id:05d}_*.err"
+                )
+            )
+        )
+    )
+
+    if not files:
+        return False
+
+    match = re.search(
+        (
+            rf"{options.tel_id}"
+            rf"_catB_tailcuts_"
+            rf"{run_id:05d}"
+            rf"_(\d+)\.err"
+        ),
+        files[-1],
+    )
+
+    if match is None:
+        return False
+
+    job_id = match.group(1)
+
+    try:
+
+        state = get_sacct_output(
+            run_sacct(job_id=job_id)
+        )["State"].item()
+
+    except Exception:
+        return False
+
+    return state in (
+        "RUNNING",
+        "PENDING",
+    )
     
-        
 def main():
     """
-    Main script to be called as cron job. It launches the Cat-B calibration script 
-    and the tailcuts finder script for each run of the corresponding date, and creates
-    the catB_{run}.closed files if Cat-B calibration has finished successfully.
-    """ 
+    Main script to be called as cron job.
+
+    It checks which runs are ready for CatB/tailcuts processing and
+    submits a pilot job executing catb_tailcuts_pipeline.py.
+    """
+
     opts = parser.parse_args()
+
+    options.input_state = opts.input_state
     options.tel_id = opts.tel_id
     options.simulate = opts.simulate
+    options.verbose = opts.verbose
     options.overwrite_tailcuts = opts.overwrite_tailcuts
     options.overwrite_catB = opts.overwrite_catB
+
     options.date = opts.date
     options.date = set_default_date_if_needed()
+
     options.configfile = opts.config.resolve()
+
     options.directory = analysis_path(options.tel_id)
 
     if opts.verbose:
@@ -240,24 +285,69 @@ def main():
     else:
         log.setLevel(logging.INFO)
 
-    run_summary_dir = Path(cfg.get(options.tel_id, "RUN_SUMMARY_DIR"))
-    run_summary = Table.read(run_summary_dir / f"RunSummary_{date_to_dir(options.date)}.ecsv")
-    data_runs = run_summary[run_summary["run_type"]=="DATA"]
+    run_summary_dir = Path(
+        cfg.get(options.tel_id, "RUN_SUMMARY_DIR")
+    )
+
+    run_summary = Table.read(
+        run_summary_dir
+        / f"RunSummary_{date_to_dir(options.date)}.ecsv"
+    )
+
+    data_runs = run_summary[
+        run_summary["run_type"] == "DATA"
+    ]
+
     for run_id in data_runs["run_id"]:
-        # first check if the dl1a files are produced
+
+        # First check if DL1A has been produced
         if not r0_to_dl1_step_finished_for_run(run_id):
-            log.info(f"The r0_to_dl1 step did not finish yet for run {run_id:05d}. Please try again later.")
-        else:
-            # launch catB calibration and tailcut finder in parallel
-            if cfg.getboolean("lstchain", "apply_catB_calibration") and not catB_closed_file_exists(run_id):
-                launch_catB_calibration(run_id)
-            if not cfg.getboolean("lstchain", "apply_standard_dl1b_config"):
-                if tailcuts_config_file_exists(run_id) and not options.overwrite_tailcuts:
-                    log.debug(
-                        f"Tailcuts config file already exists for run {run_id:05d}. Use --overwrite-tailcuts to overwrite it."
-                    )
-                else:
-                    launch_tailcuts_finder(run_id)
+
+            log.info(
+                f"The r0_to_dl1 step did not finish yet "
+                f"for run {run_id:05d}. "
+                f"Please try again later."
+            )
+
+            continue
+
+        need_catb = (
+            cfg.getboolean(
+                "lstchain",
+                "apply_catB_calibration",
+            )
+            and not catB_closed_file_exists(run_id)
+        )
+
+        need_tailcuts = (
+            not cfg.getboolean(
+                "lstchain",
+                "apply_standard_dl1b_config",
+            )
+            and (
+                not tailcuts_config_file_exists(run_id)
+                or options.overwrite_tailcuts
+            )
+        )
+
+        if not (need_catb or need_tailcuts):
+
+            log.debug(
+                f"Run {run_id:05d} already processed."
+            )
+
+            continue
+
+        if pilot_job_is_active(run_id):
+
+            log.debug(
+                f"Pilot job already active for run "
+                f"{run_id:05d}"
+            )
+
+            continue
+
+        submit_pilot_script(run_id)
 
 
 if __name__ == "__main__":

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -79,6 +79,18 @@ def r0_to_dl1_step_finished_for_run(run_id: int) -> bool:
             return False
     return True
 
+def create_run_history_file(run_id: int) -> Path:
+    """Create the run-level history file if it does not exist."""
+
+    history_file = (
+        Path(options.directory)
+        / f"{options.tel_id}_{run_id:05d}.history"
+    )
+
+    history_file.touch(exist_ok=True)
+
+    return history_file
+
 
 def tailcuts_config_file_exists(run_id: int) -> bool:
     """Check if the config file created by the tailcuts finder script already exists."""
@@ -339,7 +351,8 @@ def main():
             )
 
             continue
-
+            
+        create_run_history_file(run_id)
         submit_pilot_script(run_id)
 
 

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -162,7 +162,7 @@ def write_pilot_script(run_id: int) -> Path:
     worker_argv.append(options.tel_id)
 
     content = ""
-    content += "#!/usr/bin/env python\n\n"
+    content += "#!/usr/bin/env python3\n\n"
 
     content += f"#SBATCH --job-name={job_name}\n"
     content += f"#SBATCH --chdir={options.directory}\n"
@@ -273,8 +273,12 @@ def pilot_job_is_active(run_id: int) -> bool:
             run_sacct(job_id=job_id)
         )["State"].item()
 
-    except Exception:
-        return False
+    except Exception as e:
+        log.warning(
+            f"Could not query sacct for job {job_id} (run {run_id:05d}): {e}. "
+            "Assuming job is active to avoid duplicate submissions."
+        )
+        return True
 
     return state in (
         "RUNNING",
@@ -290,6 +294,10 @@ def main():
     """
 
     opts = parser.parse_args()
+    if opts.tel_id == "all":
+        parser.error(
+            "tel_id 'all' is not supported by sequencer_catB_tailcuts; run separately for ST, LST1, or LST2."
+        )
 
     options.input_state = opts.input_state
     options.tel_id = opts.tel_id

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -211,17 +211,10 @@ def pilot_job_is_active(run_id: int) -> bool:
 
     log_dir = Path(options.directory) / "log"
 
+    pattern = rf"{options.tel_id}_catB_tailcuts_{run_id:05d}_(\d+)\.err$"
     files = sorted(
-        glob.glob(
-            str(
-                log_dir
-                / (
-                    f"{options.tel_id}"
-                    f"_catB_tailcuts_"
-                    f"{run_id:05d}_*.err"
-                )
-            )
-        )
+        glob.glob(str(log_dir / f"{options.tel_id}_catB_tailcuts_{run_id:05d}_*.err")),
+        key=lambda p: int(re.search(pattern, p).group(1)) if re.search(pattern, p) else -1,
     )
 
     if not files:

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -56,7 +56,7 @@ def are_all_history_files_created(run_id: int) -> bool:
     run_summary = Table.read(run_summary_file)
     n_subruns = run_summary[run_summary["run_id"] == run_id]["n_subruns"]
     analysis_dir = Path(options.directory)
-    history_files = glob.glob(f"{str(analysis_dir)}/sequence_LST1_{run_id:05d}.????.history")
+    history_files = glob.glob(f"{analysis_dir}/sequence_{options.tel_id}_{run_id:05d}.????.history")
     if len(history_files) == n_subruns:
         return True
     else:
@@ -72,7 +72,7 @@ def r0_to_dl1_step_finished_for_run(run_id: int) -> bool:
         log.debug(f"All history files for run {run_id:05d} were not created yet.")
         return False
     analysis_dir = Path(options.directory)
-    history_files = glob.glob(f"{str(analysis_dir)}/sequence_LST1_{run_id:05d}.????.history")
+    history_files = glob.glob(f"{analysis_dir}/sequence_{options.tel_id}_{run_id:05d}.????.history")
     for file in history_files:
         rc = Path(file).read_text().splitlines()[-1][-1]
         if rc != "0":

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -82,7 +82,6 @@ def r0_to_dl1_step_finished_for_run(run_id: int) -> bool:
 
 def create_run_history_file(run_id: int) -> Path:
     """Create the run-level history file if it does not exist."""
-
     history_file = (
         Path(options.directory)
         / f"{options.tel_id}_{run_id:05d}.history"

--- a/src/osa/scripts/sequencer_catB_tailcuts.py
+++ b/src/osa/scripts/sequencer_catB_tailcuts.py
@@ -45,8 +45,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "tel_id",
-    choices=["ST", "LST1", "LST2", "all"],
-    help="telescope identifier LST1, LST2, ST or all.",
+    choices=["LST1", "LST2", "all"],
+    help="telescope identifier LST1, LST2 or all.",
 )
 
 def are_all_history_files_created(run_id: int) -> bool:

--- a/src/osa/scripts/tests/test_osa_scripts.py
+++ b/src/osa/scripts/tests/test_osa_scripts.py
@@ -25,6 +25,8 @@ ALL_SCRIPTS = [
     "source_coordinates",
     "sequencer_webmaker",
     "gainsel_webmaker",
+    "sequencer_catB_tailcuts",
+    "catb_tailcuts_pipeline",
 ]
 
 options.date = datetime.datetime.fromisoformat("2020-01-17")

--- a/src/osa/scripts/troubleshooting.py
+++ b/src/osa/scripts/troubleshooting.py
@@ -23,6 +23,7 @@ JOB_CATEGORIES_MAP = {
     "CatB": "CAT_B",
     "onsite_create_cat_B_calibration_file": "CAT_B",
     "lstchain_find_tailcuts": "CAT_B",
+    "catB_tailcuts": "CAT_B",
     "LST1_": "SEQUENCER",
     "lstchain_dl1_to_dl2": "CLOSER",
     "closer": "CLOSER"


### PR DESCRIPTION
This PR introduces a sequencer → pilot → worker workflow for CatB/Tailcuts processing. Instead of running CatB and Tailcuts directly from the sequencer, sequencer_catB_tailcuts.py now submits pilot jobs that execute catb_tailcuts_pipeline.py on a run-by-run basis.